### PR TITLE
Add Virtual File System (VFS) core implementation

### DIFF
--- a/src/main/java/linuxlingo/shell/vfs/Directory.java
+++ b/src/main/java/linuxlingo/shell/vfs/Directory.java
@@ -1,0 +1,61 @@
+package linuxlingo.shell.vfs;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A directory node in the VFS. Contains child nodes.
+ */
+public class Directory extends FileNode {
+    private final LinkedHashMap<String, FileNode> children;
+
+    public Directory(String name, Permission perm) {
+        super(name, perm);
+        this.children = new LinkedHashMap<>();
+    }
+
+    public void addChild(FileNode child) {
+        child.setParent(this);
+        children.put(child.getName(), child);
+    }
+
+    public void removeChild(String name) {
+        FileNode child = children.remove(name);
+        if (child != null) {
+            child.setParent(null);
+        }
+    }
+
+    public FileNode getChild(String name) {
+        return children.get(name);
+    }
+
+    public List<FileNode> getChildren() {
+        return new ArrayList<>(children.values());
+    }
+
+    public boolean hasChild(String name) {
+        return children.containsKey(name);
+    }
+
+    public boolean isEmpty() {
+        return children.isEmpty();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return true;
+    }
+
+    @Override
+    public Directory deepCopy() {
+        Directory copy = new Directory(getName(), getPermission().copy());
+        for (Map.Entry<String, FileNode> entry : children.entrySet()) {
+            FileNode childCopy = entry.getValue().deepCopy();
+            copy.addChild(childCopy);
+        }
+        return copy;
+    }
+}

--- a/src/main/java/linuxlingo/shell/vfs/FileNode.java
+++ b/src/main/java/linuxlingo/shell/vfs/FileNode.java
@@ -1,0 +1,55 @@
+package linuxlingo.shell.vfs;
+
+/**
+ * Abstract base class for all VFS nodes (files and directories).
+ */
+public abstract class FileNode {
+    private String name;
+    private Permission permission;
+    private Directory parent;
+
+    protected FileNode(String name, Permission permission) {
+        this.name = name;
+        this.permission = permission;
+        this.parent = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Permission getPermission() {
+        return permission;
+    }
+
+    public void setPermission(Permission permission) {
+        this.permission = permission;
+    }
+
+    public Directory getParent() {
+        return parent;
+    }
+
+    public void setParent(Directory parent) {
+        this.parent = parent;
+    }
+
+    public String getAbsolutePath() {
+        if (parent == null) {
+            return "/";
+        }
+        String parentPath = parent.getAbsolutePath();
+        if (parentPath.equals("/")) {
+            return "/" + name;
+        }
+        return parentPath + "/" + name;
+    }
+
+    public abstract boolean isDirectory();
+
+    public abstract FileNode deepCopy();
+}

--- a/src/main/java/linuxlingo/shell/vfs/Permission.java
+++ b/src/main/java/linuxlingo/shell/vfs/Permission.java
@@ -1,0 +1,147 @@
+package linuxlingo.shell.vfs;
+
+/**
+ * Permission model for VFS nodes.
+ * Represents Unix-like 9-character permission string (e.g., "rwxr-xr-x").
+ */
+public class Permission {
+    private final boolean[] bits; // length 9
+
+    public Permission(String permString) {
+        if (permString.length() != 9) {
+            throw new IllegalArgumentException("Permission string must be 9 characters: " + permString);
+        }
+        bits = new boolean[9];
+        char[] expected = {'r', 'w', 'x', 'r', 'w', 'x', 'r', 'w', 'x'};
+        for (int i = 0; i < 9; i++) {
+            char c = permString.charAt(i);
+            if (c == expected[i] || (i == 8 && c == 't')) {
+                bits[i] = true;
+            } else if (c == '-' || (i == 8 && c == 'T')) {
+                bits[i] = (c == 'T' || c == 't'); // sticky bit edge case
+                if (c == '-') {
+                    bits[i] = false;
+                }
+            } else if (c == 's' || c == 'S') {
+                bits[i] = (c == 's');
+            } else {
+                bits[i] = false;
+            }
+        }
+    }
+
+    private Permission(boolean[] bits) {
+        this.bits = bits.clone();
+    }
+
+    public static Permission fromOctal(String octal) {
+        if (octal.length() != 3) {
+            throw new IllegalArgumentException("Octal permission must be 3 digits: " + octal);
+        }
+        boolean[] b = new boolean[9];
+        for (int i = 0; i < 3; i++) {
+            int digit = octal.charAt(i) - '0';
+            if (digit < 0 || digit > 7) {
+                throw new IllegalArgumentException("Invalid octal digit: " + octal.charAt(i));
+            }
+            b[i * 3] = (digit & 4) != 0;
+            b[i * 3 + 1] = (digit & 2) != 0;
+            b[i * 3 + 2] = (digit & 1) != 0;
+        }
+        return new Permission(b);
+    }
+
+    public static Permission fromSymbolic(String symbolic, Permission current) {
+        boolean[] b = current.bits.clone();
+        // Parse e.g. "u+x", "g-w", "o+rw", "a+x", "u=rwx"
+        int i = 0;
+        while (i < symbolic.length()) {
+            // Parse who
+            boolean user = false, group = false, others = false;
+            while (i < symbolic.length() && "ugoa".indexOf(symbolic.charAt(i)) >= 0) {
+                switch (symbolic.charAt(i)) {
+                case 'u' -> user = true;
+                case 'g' -> group = true;
+                case 'o' -> others = true;
+                case 'a' -> { user = true; group = true; others = true; }
+                default -> { }
+                }
+                i++;
+            }
+            if (!user && !group && !others) {
+                user = true; group = true; others = true;
+            }
+            if (i >= symbolic.length()) break;
+            char op = symbolic.charAt(i++);
+            // Parse permissions
+            boolean r = false, w = false, x = false;
+            while (i < symbolic.length() && "rwx".indexOf(symbolic.charAt(i)) >= 0) {
+                switch (symbolic.charAt(i)) {
+                case 'r' -> r = true;
+                case 'w' -> w = true;
+                case 'x' -> x = true;
+                default -> { }
+                }
+                i++;
+            }
+            // Apply
+            switch (op) {
+            case '+' -> {
+                if (user) { if (r) b[0] = true; if (w) b[1] = true; if (x) b[2] = true; }
+                if (group) { if (r) b[3] = true; if (w) b[4] = true; if (x) b[5] = true; }
+                if (others) { if (r) b[6] = true; if (w) b[7] = true; if (x) b[8] = true; }
+            }
+            case '-' -> {
+                if (user) { if (r) b[0] = false; if (w) b[1] = false; if (x) b[2] = false; }
+                if (group) { if (r) b[3] = false; if (w) b[4] = false; if (x) b[5] = false; }
+                if (others) { if (r) b[6] = false; if (w) b[7] = false; if (x) b[8] = false; }
+            }
+            case '=' -> {
+                if (user) { b[0] = r; b[1] = w; b[2] = x; }
+                if (group) { b[3] = r; b[4] = w; b[5] = x; }
+                if (others) { b[6] = r; b[7] = w; b[8] = x; }
+            }
+            default -> { }
+            }
+            // Skip comma separators
+            if (i < symbolic.length() && symbolic.charAt(i) == ',') i++;
+        }
+        return new Permission(b);
+    }
+
+    public boolean canOwnerRead() { return bits[0]; }
+    public boolean canOwnerWrite() { return bits[1]; }
+    public boolean canOwnerExecute() { return bits[2]; }
+    public boolean canGroupRead() { return bits[3]; }
+    public boolean canGroupWrite() { return bits[4]; }
+    public boolean canGroupExecute() { return bits[5]; }
+    public boolean canOtherRead() { return bits[6]; }
+    public boolean canOtherWrite() { return bits[7]; }
+    public boolean canOtherExecute() { return bits[8]; }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(9);
+        sb.append(bits[0] ? 'r' : '-');
+        sb.append(bits[1] ? 'w' : '-');
+        sb.append(bits[2] ? 'x' : '-');
+        sb.append(bits[3] ? 'r' : '-');
+        sb.append(bits[4] ? 'w' : '-');
+        sb.append(bits[5] ? 'x' : '-');
+        sb.append(bits[6] ? 'r' : '-');
+        sb.append(bits[7] ? 'w' : '-');
+        sb.append(bits[8] ? 'x' : '-');
+        return sb.toString();
+    }
+
+    public String toOctal() {
+        int owner = (bits[0] ? 4 : 0) + (bits[1] ? 2 : 0) + (bits[2] ? 1 : 0);
+        int group = (bits[3] ? 4 : 0) + (bits[4] ? 2 : 0) + (bits[5] ? 1 : 0);
+        int other = (bits[6] ? 4 : 0) + (bits[7] ? 2 : 0) + (bits[8] ? 1 : 0);
+        return "" + owner + group + other;
+    }
+
+    public Permission copy() {
+        return new Permission(bits);
+    }
+}

--- a/src/main/java/linuxlingo/shell/vfs/RegularFile.java
+++ b/src/main/java/linuxlingo/shell/vfs/RegularFile.java
@@ -1,0 +1,39 @@
+package linuxlingo.shell.vfs;
+
+/**
+ * A regular file node in the VFS. Holds text content.
+ */
+public class RegularFile extends FileNode {
+    private String content;
+
+    public RegularFile(String name, Permission perm, String content) {
+        super(name, perm);
+        this.content = content == null ? "" : content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content == null ? "" : content;
+    }
+
+    public void appendContent(String text) {
+        this.content += text;
+    }
+
+    public int getSize() {
+        return content.length();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public RegularFile deepCopy() {
+        return new RegularFile(getName(), getPermission().copy(), content);
+    }
+}

--- a/src/main/java/linuxlingo/shell/vfs/VfsException.java
+++ b/src/main/java/linuxlingo/shell/vfs/VfsException.java
@@ -1,0 +1,10 @@
+package linuxlingo.shell.vfs;
+
+/**
+ * Runtime exception for VFS operations (path not found, permission denied, etc.).
+ */
+public class VfsException extends RuntimeException {
+    public VfsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/linuxlingo/shell/vfs/VirtualFileSystem.java
+++ b/src/main/java/linuxlingo/shell/vfs/VirtualFileSystem.java
@@ -1,0 +1,422 @@
+package linuxlingo.shell.vfs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Facade for Virtual File System operations.
+ * Provides path resolution, file/directory creation, deletion, copy, move, etc.
+ */
+public class VirtualFileSystem {
+    private final Directory root;
+
+    public VirtualFileSystem() {
+        this.root = createDefaultTree();
+    }
+
+    public VirtualFileSystem(Directory root) {
+        this.root = root;
+    }
+
+    /**
+     * Create the default VFS tree structure.
+     */
+    public static Directory createDefaultTree() {
+        Directory root = new Directory("", new Permission("rwxr-xr-x"));
+        Directory home = new Directory("home", new Permission("rwxr-xr-x"));
+        Directory user = new Directory("user", new Permission("rwxr-xr-x"));
+        Directory tmp = new Directory("tmp", new Permission("rwxrwxrwx"));
+        Directory etc = new Directory("etc", new Permission("rwxr-xr-x"));
+        RegularFile hostname = new RegularFile("hostname", new Permission("rw-r--r--"), "linuxlingo");
+        root.addChild(home);
+        home.addChild(user);
+        root.addChild(tmp);
+        root.addChild(etc);
+        etc.addChild(hostname);
+        return root;
+    }
+
+    /**
+     * Resolve a path string to a FileNode.
+     * @throws VfsException if path not found
+     */
+    public FileNode resolve(String path, String workingDir) {
+        List<String> parts = normalizePath(path, workingDir);
+        FileNode current = root;
+        for (String part : parts) {
+            if (!current.isDirectory()) {
+                throw new VfsException("Not a directory: " + current.getAbsolutePath());
+            }
+            FileNode child = ((Directory) current).getChild(part);
+            if (child == null) {
+                throw new VfsException("No such file or directory: " + path);
+            }
+            current = child;
+        }
+        return current;
+    }
+
+    /**
+     * Resolve the parent directory of a path.
+     */
+    public Directory resolveParent(String path, String workingDir) {
+        List<String> parts = normalizePath(path, workingDir);
+        if (parts.isEmpty()) {
+            return null; // root has no parent
+        }
+        FileNode current = root;
+        for (int i = 0; i < parts.size() - 1; i++) {
+            if (!current.isDirectory()) {
+                throw new VfsException("Not a directory: " + current.getAbsolutePath());
+            }
+            FileNode child = ((Directory) current).getChild(parts.get(i));
+            if (child == null) {
+                throw new VfsException("No such file or directory: " + path);
+            }
+            current = child;
+        }
+        if (!current.isDirectory()) {
+            throw new VfsException("Not a directory: " + current.getAbsolutePath());
+        }
+        return (Directory) current;
+    }
+
+    /**
+     * Get the basename (last component) of a path.
+     */
+    public String getBaseName(String path, String workingDir) {
+        List<String> parts = normalizePath(path, workingDir);
+        if (parts.isEmpty()) {
+            return "";
+        }
+        return parts.get(parts.size() - 1);
+    }
+
+    public RegularFile createFile(String path, String workingDir) {
+        Directory parent = resolveParent(path, workingDir);
+        if (parent == null) {
+            throw new VfsException("Cannot create file at root");
+        }
+        String name = getBaseName(path, workingDir);
+        if (parent.hasChild(name)) {
+            FileNode existing = parent.getChild(name);
+            if (existing.isDirectory()) {
+                throw new VfsException("Is a directory: " + path);
+            }
+            return (RegularFile) existing; // touch existing file
+        }
+        if (!parent.getPermission().canOwnerWrite()) {
+            throw new VfsException("Permission denied: " + path);
+        }
+        RegularFile file = new RegularFile(name, new Permission("rw-r--r--"), "");
+        parent.addChild(file);
+        return file;
+    }
+
+    public Directory createDirectory(String path, String workingDir, boolean parents) {
+        if (parents) {
+            return createDirectoryRecursive(path, workingDir);
+        }
+        Directory parent = resolveParent(path, workingDir);
+        if (parent == null) {
+            throw new VfsException("Cannot create directory at root");
+        }
+        String name = getBaseName(path, workingDir);
+        if (parent.hasChild(name)) {
+            FileNode existing = parent.getChild(name);
+            if (existing.isDirectory()) {
+                if (parents) {
+                    return (Directory) existing;
+                }
+                throw new VfsException("Directory already exists: " + path);
+            }
+            throw new VfsException("File exists: " + path);
+        }
+        if (!parent.getPermission().canOwnerWrite()) {
+            throw new VfsException("Permission denied: " + path);
+        }
+        Directory dir = new Directory(name, new Permission("rwxr-xr-x"));
+        parent.addChild(dir);
+        return dir;
+    }
+
+    private Directory createDirectoryRecursive(String path, String workingDir) {
+        List<String> parts = normalizePath(path, workingDir);
+        FileNode current = root;
+        for (String part : parts) {
+            if (!current.isDirectory()) {
+                throw new VfsException("Not a directory: " + current.getAbsolutePath());
+            }
+            Directory dir = (Directory) current;
+            if (dir.hasChild(part)) {
+                FileNode child = dir.getChild(part);
+                if (!child.isDirectory()) {
+                    throw new VfsException("Not a directory: " + child.getAbsolutePath());
+                }
+                current = child;
+            } else {
+                Directory newDir = new Directory(part, new Permission("rwxr-xr-x"));
+                dir.addChild(newDir);
+                current = newDir;
+            }
+        }
+        return (Directory) current;
+    }
+
+    public void delete(String path, String workingDir, boolean recursive, boolean force) {
+        List<String> parts = normalizePath(path, workingDir);
+        if (parts.isEmpty()) {
+            throw new VfsException("Cannot delete root directory");
+        }
+        FileNode node;
+        try {
+            node = resolve(path, workingDir);
+        } catch (VfsException e) {
+            if (force) {
+                return;
+            }
+            throw e;
+        }
+        if (node.isDirectory() && !recursive) {
+            throw new VfsException("Cannot remove directory without -r: " + path);
+        }
+        Directory parent = node.getParent();
+        if (parent != null) {
+            parent.removeChild(node.getName());
+        }
+    }
+
+    public void copy(String srcPath, String destPath, String workingDir, boolean recursive) {
+        FileNode src = resolve(srcPath, workingDir);
+        if (src.isDirectory() && !recursive) {
+            throw new VfsException("cp: -r not specified; omitting directory '" + srcPath + "'");
+        }
+
+        // Determine destination
+        FileNode destNode = null;
+        try {
+            destNode = resolve(destPath, workingDir);
+        } catch (VfsException e) {
+            // dest doesn't exist, that's ok
+        }
+
+        if (destNode != null && destNode.isDirectory()) {
+            // Copy into directory
+            Directory destDir = (Directory) destNode;
+            FileNode copy = src.deepCopy();
+            copy.setName(src.getName());
+            destDir.addChild(copy);
+        } else if (destNode != null && !destNode.isDirectory()) {
+            // Overwrite file
+            if (src.isDirectory()) {
+                throw new VfsException("Cannot overwrite non-directory with directory");
+            }
+            RegularFile destFile = (RegularFile) destNode;
+            destFile.setContent(((RegularFile) src).getContent());
+        } else {
+            // Create new node at dest
+            Directory parent = resolveParent(destPath, workingDir);
+            if (parent == null) {
+                throw new VfsException("Cannot copy to root");
+            }
+            String name = getBaseName(destPath, workingDir);
+            FileNode copy = src.deepCopy();
+            copy.setName(name);
+            parent.addChild(copy);
+        }
+    }
+
+    public void move(String srcPath, String destPath, String workingDir) {
+        FileNode src = resolve(srcPath, workingDir);
+        List<String> srcParts = normalizePath(srcPath, workingDir);
+        if (srcParts.isEmpty()) {
+            throw new VfsException("Cannot move root directory");
+        }
+
+        FileNode destNode = null;
+        try {
+            destNode = resolve(destPath, workingDir);
+        } catch (VfsException e) {
+            // dest doesn't exist
+        }
+
+        Directory srcParent = src.getParent();
+
+        if (destNode != null && destNode.isDirectory()) {
+            // Move into directory
+            srcParent.removeChild(src.getName());
+            ((Directory) destNode).addChild(src);
+        } else if (destNode != null && !destNode.isDirectory()) {
+            // Overwrite file
+            if (src.isDirectory()) {
+                throw new VfsException("Cannot overwrite non-directory with directory");
+            }
+            Directory destParent = destNode.getParent();
+            destParent.removeChild(destNode.getName());
+            srcParent.removeChild(src.getName());
+            String newName = destNode.getName();
+            src.setName(newName);
+            destParent.addChild(src);
+        } else {
+            // Rename to new name
+            Directory parent = resolveParent(destPath, workingDir);
+            String name = getBaseName(destPath, workingDir);
+            srcParent.removeChild(src.getName());
+            src.setName(name);
+            parent.addChild(src);
+        }
+    }
+
+    public String readFile(String path, String workingDir) {
+        FileNode node = resolve(path, workingDir);
+        if (node.isDirectory()) {
+            throw new VfsException("Is a directory: " + path);
+        }
+        if (!node.getPermission().canOwnerRead()) {
+            throw new VfsException("Permission denied: " + path);
+        }
+        return ((RegularFile) node).getContent();
+    }
+
+    public void writeFile(String path, String workingDir, String content, boolean append) {
+        FileNode node;
+        try {
+            node = resolve(path, workingDir);
+        } catch (VfsException e) {
+            // File doesn't exist, create it
+            node = createFile(path, workingDir);
+        }
+        if (node.isDirectory()) {
+            throw new VfsException("Is a directory: " + path);
+        }
+        if (!node.getPermission().canOwnerWrite()) {
+            throw new VfsException("Permission denied: " + path);
+        }
+        RegularFile file = (RegularFile) node;
+        if (append) {
+            file.appendContent(content);
+        } else {
+            file.setContent(content);
+        }
+    }
+
+    public List<FileNode> listDirectory(String path, String workingDir, boolean showHidden) {
+        FileNode node = resolve(path, workingDir);
+        if (!node.isDirectory()) {
+            throw new VfsException("Not a directory: " + path);
+        }
+        if (!node.getPermission().canOwnerRead()) {
+            throw new VfsException("Permission denied: " + path);
+        }
+        List<FileNode> children = ((Directory) node).getChildren();
+        if (!showHidden) {
+            children = children.stream()
+                    .filter(c -> !c.getName().startsWith("."))
+                    .collect(java.util.stream.Collectors.toList());
+        }
+        return children;
+    }
+
+    public Directory getRoot() {
+        return root;
+    }
+
+    public VirtualFileSystem deepCopy() {
+        return new VirtualFileSystem(root.deepCopy());
+    }
+
+    /**
+     * Find nodes by name pattern (supports * wildcard).
+     */
+    public List<FileNode> findByName(String startPath, String workingDir, String pattern) {
+        FileNode start = resolve(startPath, workingDir);
+        if (!start.isDirectory()) {
+            throw new VfsException("Not a directory: " + startPath);
+        }
+        List<FileNode> results = new ArrayList<>();
+        findRecursive((Directory) start, pattern, results);
+        return results;
+    }
+
+    private void findRecursive(Directory dir, String pattern, List<FileNode> results) {
+        for (FileNode child : dir.getChildren()) {
+            if (matchesWildcard(pattern, child.getName())) {
+                results.add(child);
+            }
+            if (child.isDirectory()) {
+                findRecursive((Directory) child, pattern, results);
+            }
+        }
+    }
+
+    public static boolean matchesWildcard(String pattern, String name) {
+        String regex = "";
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (c == '*') {
+                regex += ".*";
+            } else if (c == '?') {
+                regex += ".";
+            } else if (".+^${}[]|()\\".indexOf(c) >= 0) {
+                regex += "\\" + c;
+            } else {
+                regex += c;
+            }
+        }
+        return name.matches("^" + regex + "$");
+    }
+
+    /**
+     * Check if a path exists.
+     */
+    public boolean exists(String path, String workingDir) {
+        try {
+            resolve(path, workingDir);
+            return true;
+        } catch (VfsException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Normalize a path string into a list of path components.
+     */
+    List<String> normalizePath(String pathString, String workingDir) {
+        String[] rawParts;
+        if (pathString.startsWith("/")) {
+            rawParts = pathString.split("/");
+        } else if (pathString.startsWith("~")) {
+            String rest = pathString.length() > 1 ? pathString.substring(2) : "";
+            String expanded = "/home/user" + (rest.isEmpty() ? "" : "/" + rest);
+            rawParts = expanded.split("/");
+        } else {
+            String abs = workingDir + "/" + pathString;
+            rawParts = abs.split("/");
+        }
+
+        List<String> resolved = new ArrayList<>();
+        for (String part : rawParts) {
+            if (part.isEmpty() || part.equals(".")) {
+                // skip empty parts and current-dir references
+            } else if (part.equals("..")) {
+                if (!resolved.isEmpty()) {
+                    resolved.remove(resolved.size() - 1);
+                }
+            } else {
+                resolved.add(part);
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Get the absolute path for a given path string.
+     */
+    public String getAbsolutePath(String path, String workingDir) {
+        List<String> parts = normalizePath(path, workingDir);
+        if (parts.isEmpty()) {
+            return "/";
+        }
+        return "/" + String.join("/", parts);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #8

Implements the complete Virtual File System (VFS) layer that underpins the LinuxLingo shell simulation. The VFS provides an in-memory filesystem tree that shell commands (`cd`, `ls`, `mkdir`, `rm`, `cp`, `mv`, etc.) will operate against.

---

## Changes

| File | Description |
|------|-------------|
| `FileNode.java` | Abstract base class for all filesystem nodes; manages name, parent reference, permissions, and absolute path resolution |
| `Directory.java` | Concrete directory node; supports `addChild`, `removeChild`, and `getChild` by name |
| `RegularFile.java` | Concrete regular-file node; stores and exposes text content |
| `Permission.java` | Unix-style `rwxrwxrwx` permission model with octal representation and per-role access checks |
| `VfsException.java` | Unchecked exception for propagating VFS-specific errors |
| `VirtualFileSystem.java` | Facade providing full path resolution, `ls`, `mkdir`, `touch`, `rm`, `cp`, `mv`, `pwd`, and a default in-memory tree (`/home/user`, `/tmp`, `/etc/hostname`) |

---

## Testing

- All new classes compile cleanly under `./gradlew build`.
- Manual smoke-testing of path resolution, directory traversal, copy, and move operations performed locally.

---

## Notes for Reviewers

- The VFS is purely in-memory; no disk I/O is involved.
- Absolute and relative path inputs are both supported via `normalizePath`.
- `Permission` is immutable; a new instance is returned on any modification.