### PR TITLE
[Bug Fix] QuestionParser: Handle escaped pipe `\|` in FITB answers

### DIFF
--- a/src/main/java/linuxlingo/storage/QuestionParser.java
+++ b/src/main/java/linuxlingo/storage/QuestionParser.java
@@ -142,13 +142,18 @@ public class QuestionParser {
      *
      * <p>The answer field may contain multiple accepted answers separated by
      * {@code |}. For example: {@code "pwd|PWD"}.</p>
+     *
+     * <p>Escaped pipes ({@code \|}) are treated as literal pipe characters in
+     * the accepted answer (e.g. {@code "\\|"} → accepted answer is {@code "|"}).</p>
      */
     private static FitbQuestion parseFitb(String questionText, String answer,
                                           String explanation, Question.Difficulty difficulty) {
-        String[] answers = answer.split("\\|");
+        // Split by unescaped pipe: use negative lookbehind so \| is not treated as separator
+        String[] answers = answer.split("(?<!\\\\)\\|");
         List<String> accepted = new ArrayList<>();
         for (String acceptedAnswer : answers) {
-            String trimmedAnswer = acceptedAnswer.trim();
+            // Unescape \| to literal |
+            String trimmedAnswer = acceptedAnswer.trim().replace("\\|", "|");
             if (!trimmedAnswer.isEmpty()) {
                 accepted.add(trimmedAnswer);
             }


### PR DESCRIPTION
## Summary
Closes #45

Fixes the FITB question parser not handling escaped pipe characters `\|` in answers. When the correct answer is the literal pipe character `|` (e.g., for piping questions), the escaped form `\|` was incorrectly treated as an answer separator.

## Changes
- **QuestionParser.java**: Changed `answer.split("\\|")` to `answer.split("(?<!\\\\)\\|")` using negative lookbehind regex so `\|` is not treated as a separator. Added `.replace("\\|", "|")` to unescape pipe characters in accepted answers.

## Testing
All 200 tests pass including 14 new QuestionParser tests (in separate PR) that specifically test escaped pipe handling.