### PR TITLE
[Bug Fix] VfsSerializer: Fix deserialization of files with empty content

### DIFF
--- a/src/main/java/linuxlingo/storage/VfsSerializer.java
+++ b/src/main/java/linuxlingo/storage/VfsSerializer.java
@@ -131,7 +131,10 @@ public class VfsSerializer {
                 continue;
             }
 
-            String[] parts = line.split(" \\| ", 4);
+            // Re-add trailing space so split works when content is empty
+            // (trim() removes the trailing space from "... | rwxr-xr-x | ")
+            String splitLine = line.endsWith("|") ? line + " " : line;
+            String[] parts = splitLine.split(" \\| ", 4);
             if (parts.length < 3) {
                 continue;
             }


### PR DESCRIPTION
## Summary
Closes #46

Fixes `VfsSerializer.deserialize()` failing to restore files with empty content. When a FILE node has empty content, the serialized line ends with `" | "`. During deserialization, `trim()` removes the trailing space, turning the delimiter into just `|`. Then `split(" \\| ", 4)` cannot produce the expected 4 parts, so the file is silently skipped.

## Changes
- **VfsSerializer.java**: After trimming, check if the line ends with `|` (indicating an empty content field). If so, re-append a trailing space so `split(" \\| ", 4)` produces the expected 4 parts.

## Testing
All 200 tests pass including 12 new VfsSerializer tests (in separate PR) covering round-trip serialization, empty files, special content, and permissions preservation.