### PR TITLE
[Bug Fix] GrepCommand: Fix stdin filtering and add -v invert match flag

### DIFF
--- a/src/main/java/linuxlingo/shell/command/GrepCommand.java
+++ b/src/main/java/linuxlingo/shell/command/GrepCommand.java
@@ -9,7 +9,7 @@ import linuxlingo.shell.vfs.VfsException;
 
 /**
  * Searches for a pattern in a file.
- * Syntax: grep [-i] [-n] [-c] &lt;pattern&gt; &lt;file&gt;
+ * Syntax: grep [-i] [-v] [-n] [-c] &lt;pattern&gt; &lt;file&gt;
  *
  * <p><b>Owner: C</b></p>
  */
@@ -19,6 +19,7 @@ public class GrepCommand implements Command {
         boolean ignoreCase = false;
         boolean showLineNumbers = false;
         boolean countOnly = false;
+        boolean invertMatch = false;
 
         String pattern = null;
         String file = null;
@@ -30,6 +31,8 @@ public class GrepCommand implements Command {
                 showLineNumbers = true;
             } else if (arg.equals("-c")) {
                 countOnly = true;
+            } else if (arg.equals("-v")) {
+                invertMatch = true;
             } else if (!arg.startsWith("-")) {
                 if (pattern == null) {
                     pattern = arg;
@@ -53,7 +56,7 @@ public class GrepCommand implements Command {
                 return CommandResult.error("grep: " + e.getMessage());
             }
         } else if (stdin != null) {
-            return CommandResult.success(stdin);
+            content = stdin;
         } else {
             return CommandResult.error("grep: missing file operand");
         }
@@ -73,6 +76,9 @@ public class GrepCommand implements Command {
             String searchLine = ignoreCase ? line.toLowerCase() : line;
 
             boolean matches = searchLine.contains(searchPattern);
+            if (invertMatch) {
+                matches = !matches;
+            }
             if (matches) {
                 count++;
                 if (countOnly) {
@@ -100,7 +106,7 @@ public class GrepCommand implements Command {
 
     @Override
     public String getUsage() {
-        return "grep [-i] [-n] [-c] <pattern> <file>";
+        return "grep [-i] [-v] [-n] [-c] <pattern> <file>";
     }
 
     @Override


### PR DESCRIPTION
## Summary
Closes #44

Fixes two bugs in `GrepCommand`:

### Bug 1: stdin passed through without filtering
When `grep` receives input from a pipe (stdin), the content was returned verbatim instead of being filtered by the pattern. The `stdin` branch directly returned `CommandResult.success(stdin)` instead of assigning `stdin` to the `content` variable for subsequent filtering.

### Bug 2: Missing `-v` (invert match) flag
The `-v` flag for inverting match was not implemented.

## Changes
- **GrepCommand.java**: Assigned `stdin` to `content` variable so the filtering loop processes piped input. Added `invertMatch` boolean, `-v` flag parsing, and inversion logic. Updated usage string and Javadoc.

## Testing
All 200 tests pass including 5 new GrepCommand tests covering `-v` flag and stdin filtering (in separate PR).