### PR TITLE
v2.0 Exam Module Enhancements: Checkpoints, Setup Items & PRAC Questions

### DIFF
--- a/data/questions/permissions.txt
+++ b/data/questions/permissions.txt
@@ -12,3 +12,8 @@ FITB | EASY   | To make file.txt readable, writable, and executable by owner (oc
 FITB | MEDIUM | To add execute permission for the owner: chmod ___ file.txt | u+x | | u+x adds execute permission for the user/owner.
 FITB | MEDIUM | To remove write permission from group and others: chmod ___ file.txt | go-w | | g=group, o=others, -w removes write.
 FITB | HARD   | What octal permission represents 'rw-r--r--'? | 644 | | r=4, w=2. Owner: 4+2=6, Group: 4, Others: 4.
+
+# ── v2.0 PRAC questions ──────────────────────────────────────
+PRAC | EASY   | Create a file /home/user/script.sh and make it executable by the owner using chmod. | /home/user/script.sh:FILE,/home/user/script.sh:PERM=rwxr--r-- | | Use 'touch script.sh' then 'chmod u+x script.sh' or 'chmod 744 script.sh'.
+PRAC | MEDIUM | Set permissions on /home/user/secret.txt to be readable and writable only by the owner (no group or other access). | /home/user/secret.txt:PERM=rw------- | FILE:/home/user/secret.txt=confidential data | Use 'chmod 600 secret.txt'.
+PRAC | HARD   | Set permissions on all files inside /home/user/project recursively: directories should be rwxr-xr-x and files should be rw-r--r--. Create the directory and a file first. | /home/user/project:DIR,/home/user/project:PERM=rwxr-xr-x,/home/user/project/README.md:FILE | MKDIR:/home/user/project;FILE:/home/user/project/README.md=readme | Use 'chmod -R 755 project/' for dirs, then 'chmod 644 project/README.md'.

--- a/data/questions/text-processing.txt
+++ b/data/questions/text-processing.txt
@@ -14,3 +14,8 @@ FITB | EASY   | To show the first 5 lines of data.txt: head ___ 5 data.txt | -n 
 FITB | MEDIUM | To count the number of lines in file.txt: wc ___ file.txt | -l | | -l flag counts lines.
 FITB | MEDIUM | To search for 'hello' in file.txt ignoring case: grep ___ hello file.txt | -i | | -i flag makes grep case-insensitive.
 FITB | HARD   | To sort file.txt numerically: sort ___ file.txt | -n | | -n flag enables numeric sorting.
+
+# ── v2.0 PRAC questions ──────────────────────────────────────
+PRAC | EASY   | Create a file called notes.txt inside /home/user/docs. | /home/user/docs:DIR,/home/user/docs/notes.txt:FILE | MKDIR:/home/user/docs | Use 'touch' to create the file after navigating to the directory.
+PRAC | MEDIUM | Using grep and sort, create a file /home/user/result.txt that contains 'hello world'. | /home/user/result.txt:CONTENT_EQUALS=hello world | FILE:/home/user/data.txt=hello world\ngoodbye world\nhello world | Hint: use 'grep hello /home/user/data.txt | sort -u > /home/user/result.txt'.
+PRAC | HARD   | Remove duplicate lines from /home/user/input.txt and save the unique sorted output to /home/user/output.txt. The file should contain: apple\nbanana\ncherry | /home/user/output.txt:CONTENT_EQUALS=apple\nbanana\ncherry | FILE:/home/user/input.txt=cherry\napple\nbanana\napple\ncherry\nbanana | Use 'sort input.txt | uniq > output.txt' to sort and deduplicate.

--- a/src/main/java/linuxlingo/exam/Checkpoint.java
+++ b/src/main/java/linuxlingo/exam/Checkpoint.java
@@ -1,6 +1,8 @@
 package linuxlingo.exam;
 
 import linuxlingo.shell.vfs.FileNode;
+import linuxlingo.shell.vfs.Permission;
+import linuxlingo.shell.vfs.RegularFile;
 import linuxlingo.shell.vfs.VfsException;
 import linuxlingo.shell.vfs.VirtualFileSystem;
 
@@ -17,15 +19,23 @@ public class Checkpoint {
 
     /** The expected node type at the checkpoint path. */
     public enum NodeType {
-        DIR, FILE
+        DIR, FILE, NOT_EXISTS, CONTENT_EQUALS, PERM
     }
 
     private final String path;
     private final NodeType expectedType;
+    private final String expectedContent;
+    private final String expectedPermission;
 
     public Checkpoint(String path, NodeType expectedType) {
+        this(path, expectedType, null, null);
+    }
+
+    public Checkpoint(String path, NodeType expectedType, String expectedContent, String expectedPermission) {
         this.path = path;
         this.expectedType = expectedType;
+        this.expectedContent = expectedContent;
+        this.expectedPermission = expectedPermission;
     }
 
     public String getPath() {
@@ -36,6 +46,14 @@ public class Checkpoint {
         return expectedType;
     }
 
+    public String getExpectedContent() {
+        return expectedContent;
+    }
+
+    public String getExpectedPermission() {
+        return expectedPermission;
+    }
+
     /**
      * Check whether this checkpoint is satisfied in the given VFS.
      *
@@ -43,6 +61,22 @@ public class Checkpoint {
      * @return true if the path exists and is the expected type
      */
     public boolean matches(VirtualFileSystem vfs) {
+        switch (expectedType) {
+        case DIR:
+        case FILE:
+            return matchesDirOrFile(vfs);
+        case NOT_EXISTS:
+            return matchesNotExists(vfs);
+        case CONTENT_EQUALS:
+            return matchesContentEquals(vfs);
+        case PERM:
+            return matchesPerm(vfs);
+        default:
+            return false;
+        }
+    }
+
+    private boolean matchesDirOrFile(VirtualFileSystem vfs) {
         try {
             FileNode node = vfs.resolve(path, "/");
             if (expectedType == NodeType.DIR) {
@@ -50,6 +84,36 @@ public class Checkpoint {
             } else {
                 return !node.isDirectory();
             }
+        } catch (VfsException e) {
+            return false;
+        }
+    }
+
+    private boolean matchesNotExists(VirtualFileSystem vfs) {
+        return !vfs.exists(path, "/");
+    }
+
+    private boolean matchesContentEquals(VirtualFileSystem vfs) {
+        try {
+            FileNode node = vfs.resolve(path, "/");
+            if (node.isDirectory()) {
+                return false;
+            }
+            String content = ((RegularFile) node).getContent();
+            return content != null && content.equals(expectedContent);
+        } catch (VfsException e) {
+            return false;
+        }
+    }
+
+    private boolean matchesPerm(VirtualFileSystem vfs) {
+        try {
+            FileNode node = vfs.resolve(path, "/");
+            Permission perm = node.getPermission();
+            if (perm == null || expectedPermission == null) {
+                return false;
+            }
+            return perm.toString().equals(expectedPermission);
         } catch (VfsException e) {
             return false;
         }

--- a/src/main/java/linuxlingo/exam/question/PracQuestion.java
+++ b/src/main/java/linuxlingo/exam/question/PracQuestion.java
@@ -1,8 +1,11 @@
 package linuxlingo.exam.question;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import linuxlingo.exam.Checkpoint;
+import linuxlingo.shell.vfs.FileNode;
+import linuxlingo.shell.vfs.Permission;
 import linuxlingo.shell.vfs.VirtualFileSystem;
 
 /**
@@ -13,13 +16,20 @@ import linuxlingo.shell.vfs.VirtualFileSystem;
  *
  * <h3>Question bank format (parsed by {@code QuestionParser})</h3>
  * <pre>
- * PRAC | DIFFICULTY | questionText | path1:TYPE,path2:TYPE | (unused) | explanation
+ * PRAC | DIFFICULTY | questionText | path1:TYPE,path2:TYPE | setupItems | explanation
  * </pre>
- * Where TYPE is {@code DIR} or {@code FILE}, and checkpoints are comma-separated.
+ * Where TYPE is {@code DIR}, {@code FILE}, {@code NOT_EXISTS},
+ * {@code CONTENT_EQUALS=value}, or {@code PERM=rwxr-xr-x},
+ * and checkpoints are comma-separated.
+ *
+ * <h3>Setup Items</h3>
+ * The optional 5th field (OPTIONS) can specify initial VFS setup:
+ * {@code MKDIR:/path;FILE:/path=content;PERM:/path=rwxr-xr-x}
  *
  * <h3>Flow</h3>
  * <ol>
  *   <li>{@code ExamSession} presents the question text.</li>
+ *   <li>If setup items exist, they are applied to the VFS before the user starts.</li>
  *   <li>A temporary {@code ShellSession} is opened for the user to type commands.</li>
  *   <li>When the user types "done", the VFS is passed to {@link #checkVfs(VirtualFileSystem)}.</li>
  *   <li>Each {@link Checkpoint} is verified: correct path + correct node type.</li>
@@ -27,11 +37,48 @@ import linuxlingo.shell.vfs.VirtualFileSystem;
  */
 public class PracQuestion extends Question {
     private final List<Checkpoint> checkpoints;
+    private final List<SetupItem> setupItems;
+
+    /**
+     * Describes a VFS setup action to perform before the user starts.
+     */
+    public static class SetupItem {
+        public enum SetupType { MKDIR, FILE, PERM }
+
+        private final SetupType type;
+        private final String path;
+        private final String value; // content for FILE, permission string for PERM, null for MKDIR
+
+        public SetupItem(SetupType type, String path, String value) {
+            this.type = type;
+            this.path = path;
+            this.value = value;
+        }
+
+        public SetupType getType() {
+            return type;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
 
     public PracQuestion(String questionText, String explanation,
                         Difficulty difficulty, List<Checkpoint> checkpoints) {
+        this(questionText, explanation, difficulty, checkpoints, new ArrayList<>());
+    }
+
+    public PracQuestion(String questionText, String explanation,
+                        Difficulty difficulty, List<Checkpoint> checkpoints,
+                        List<SetupItem> setupItems) {
         super(QuestionType.PRAC, difficulty, questionText, explanation);
         this.checkpoints = checkpoints;
+        this.setupItems = setupItems != null ? setupItems : new ArrayList<>();
     }
 
     @Override
@@ -60,7 +107,71 @@ public class PracQuestion extends Question {
         return true;
     }
 
+    /**
+     * Apply setup items to the VFS before the user starts their exercise.
+     *
+     * @param vfs the virtual file system to set up
+     */
+    public void applySetup(VirtualFileSystem vfs) {
+        for (SetupItem item : setupItems) {
+            switch (item.getType()) {
+            case MKDIR:
+                vfs.createDirectory(item.getPath(), "/", true);
+                break;
+            case FILE:
+                // Ensure parent directory exists
+                String parentPath = getParentPath(item.getPath());
+                if (!"/".equals(parentPath)) {
+                    vfs.createDirectory(parentPath, "/", true);
+                }
+                vfs.createFile(item.getPath(), "/");
+                if (item.getValue() != null && !item.getValue().isEmpty()) {
+                    vfs.writeFile(item.getPath(), "/", item.getValue(), false);
+                }
+                break;
+            case PERM:
+                try {
+                    FileNode node = vfs.resolve(item.getPath(), "/");
+                    if (item.getValue() != null) {
+                        Permission basePerm = node.getPermission();
+                        if (basePerm == null) {
+                            basePerm = Permission.fromOctal("644");
+                        }
+                        node.setPermission(Permission.fromSymbolic(item.getValue(), basePerm));
+                    }
+                } catch (Exception e) {
+                    // Node doesn't exist yet — skip permission setup
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    /**
+     * Whether this question has setup items that need to be applied.
+     */
+    public boolean hasSetup() {
+        return !setupItems.isEmpty();
+    }
+
     public List<Checkpoint> getCheckpoints() {
         return checkpoints;
+    }
+
+    public List<SetupItem> getSetupItems() {
+        return setupItems;
+    }
+
+    private static String getParentPath(String path) {
+        if (path == null || path.equals("/")) {
+            return "/";
+        }
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "/";
+        }
+        return path.substring(0, lastSlash);
     }
 }

--- a/src/main/java/linuxlingo/storage/QuestionParser.java
+++ b/src/main/java/linuxlingo/storage/QuestionParser.java
@@ -89,7 +89,7 @@ public class QuestionParser {
                     questions.add(parseFitb(questionText, answer, explanation, difficulty));
                     break;
                 case "PRAC":
-                    questions.add(parsePrac(questionText, answer, explanation, difficulty));
+                    questions.add(parsePrac(questionText, answer, options, explanation, difficulty));
                     break;
                 default:
                     LOGGER.log(Level.WARNING, "Skipping unknown question type ''{0}'' at line {1} in {2}",
@@ -168,26 +168,127 @@ public class QuestionParser {
      * Parse a single PRAC line into a {@link PracQuestion}.
      *
      * <p>The answer field contains comma-separated checkpoints:
-     * {@code "/path:TYPE,/path2:TYPE"} where TYPE is {@code DIR} or {@code FILE}.</p>
+     * {@code "/path:TYPE,/path2:TYPE"} where TYPE is {@code DIR}, {@code FILE},
+     * {@code NOT_EXISTS}, {@code CONTENT_EQUALS=value}, or {@code PERM=rwxr-xr-x}.</p>
+     *
+     * <p>The options field (5th field) can specify setup items:
+     * {@code MKDIR:/path;FILE:/path=content;PERM:/path=rwxr-xr-x}</p>
      */
+    @SuppressWarnings("unused") // backward-compatible overload for team members
     private static PracQuestion parsePrac(String questionText, String answer,
                                           String explanation, Question.Difficulty difficulty) {
+        return parsePrac(questionText, answer, "", explanation, difficulty);
+    }
+
+    /**
+     * Parse a single PRAC line with optional setup items.
+     */
+    private static PracQuestion parsePrac(String questionText, String answer,
+                                          String options, String explanation,
+                                          Question.Difficulty difficulty) {
         String[] parts = answer.split(",");
         List<Checkpoint> checkpoints = new ArrayList<>();
         for (String part : parts) {
-            String[] checkpointParts = part.trim().split(":", 2);
-            if (checkpointParts.length == 2) {
-                Checkpoint.NodeType nodeType = checkpointParts[1].trim().equalsIgnoreCase("DIR")
-                        ? Checkpoint.NodeType.DIR : Checkpoint.NodeType.FILE;
-                checkpoints.add(new Checkpoint(checkpointParts[0].trim(), nodeType));
-            } else {
-                throw new IllegalArgumentException("Invalid PRAC checkpoint format: " + part);
-            }
+            checkpoints.add(parseCheckpoint(part.trim()));
         }
         if (checkpoints.isEmpty()) {
             throw new IllegalArgumentException("PRAC checkpoints must not be empty");
         }
-        return new PracQuestion(questionText, explanation, difficulty, checkpoints);
+
+        List<PracQuestion.SetupItem> setupItems = new ArrayList<>();
+        if (options != null && !options.isEmpty()) {
+            String[] setupParts = options.split(";");
+            for (String setupPart : setupParts) {
+                PracQuestion.SetupItem item = parseSetupItem(setupPart.trim());
+                if (item != null) {
+                    setupItems.add(item);
+                }
+            }
+        }
+
+        return new PracQuestion(questionText, explanation, difficulty, checkpoints, setupItems);
+    }
+
+    /**
+     * Parse a single checkpoint from a string like "/path:TYPE" or "/path:CONTENT_EQUALS=value".
+     */
+    private static Checkpoint parseCheckpoint(String part) {
+        int typeColon = findTypeColon(part);
+        if (typeColon == -1) {
+            throw new IllegalArgumentException("Invalid PRAC checkpoint format: " + part);
+        }
+
+        String path = part.substring(0, typeColon);
+        String typeStr = part.substring(typeColon + 1);
+
+        if (typeStr.equalsIgnoreCase("DIR")) {
+            return new Checkpoint(path, Checkpoint.NodeType.DIR);
+        } else if (typeStr.equalsIgnoreCase("FILE")) {
+            return new Checkpoint(path, Checkpoint.NodeType.FILE);
+        } else if (typeStr.equalsIgnoreCase("NOT_EXISTS")) {
+            return new Checkpoint(path, Checkpoint.NodeType.NOT_EXISTS);
+        } else if (typeStr.toUpperCase(Locale.ROOT).startsWith("CONTENT_EQUALS=")) {
+            String content = typeStr.substring("CONTENT_EQUALS=".length());
+            content = content.replace("\\n", "\n"); // unescape newlines
+            return new Checkpoint(path, Checkpoint.NodeType.CONTENT_EQUALS, content, null);
+        } else if (typeStr.toUpperCase(Locale.ROOT).startsWith("PERM=")) {
+            String perm = typeStr.substring("PERM=".length());
+            return new Checkpoint(path, Checkpoint.NodeType.PERM, null, perm);
+        } else {
+            throw new IllegalArgumentException("Unknown checkpoint type: " + typeStr);
+        }
+    }
+
+    /**
+     * Find the colon that separates the path from the type in a checkpoint string.
+     * Handles paths like "/home/user/file.txt:FILE" by finding the last colon
+     * that starts a known type keyword.
+     */
+    private static int findTypeColon(String part) {
+        // Try known type prefixes from the end
+        String[] knownTypes = {"DIR", "FILE", "NOT_EXISTS", "CONTENT_EQUALS=", "PERM="};
+        for (String type : knownTypes) {
+            String suffix = ":" + type;
+            int idx = part.toUpperCase(Locale.ROOT).lastIndexOf(suffix.toUpperCase(Locale.ROOT));
+            if (idx >= 0) {
+                return idx;
+            }
+        }
+        // Fallback: last colon
+        return part.lastIndexOf(':');
+    }
+
+    /**
+     * Parse a setup item from a string like "MKDIR:/path" or "FILE:/path=content".
+     */
+    private static PracQuestion.SetupItem parseSetupItem(String part) {
+        if (part.toUpperCase(Locale.ROOT).startsWith("MKDIR:")) {
+            String path = part.substring("MKDIR:".length());
+            return new PracQuestion.SetupItem(
+                    PracQuestion.SetupItem.SetupType.MKDIR, path, null);
+        } else if (part.toUpperCase(Locale.ROOT).startsWith("FILE:")) {
+            String rest = part.substring("FILE:".length());
+            int eqIdx = rest.indexOf('=');
+            if (eqIdx >= 0) {
+                String path = rest.substring(0, eqIdx);
+                String content = rest.substring(eqIdx + 1).replace("\\n", "\n");
+                return new PracQuestion.SetupItem(
+                        PracQuestion.SetupItem.SetupType.FILE, path, content);
+            } else {
+                return new PracQuestion.SetupItem(
+                        PracQuestion.SetupItem.SetupType.FILE, rest, null);
+            }
+        } else if (part.toUpperCase(Locale.ROOT).startsWith("PERM:")) {
+            String rest = part.substring("PERM:".length());
+            int eqIdx = rest.indexOf('=');
+            if (eqIdx >= 0) {
+                String path = rest.substring(0, eqIdx);
+                String perm = rest.substring(eqIdx + 1);
+                return new PracQuestion.SetupItem(
+                        PracQuestion.SetupItem.SetupType.PERM, path, perm);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/resources/questions/permissions.txt
+++ b/src/main/resources/questions/permissions.txt
@@ -12,3 +12,8 @@ FITB | EASY   | To make file.txt readable, writable, and executable by owner (oc
 FITB | MEDIUM | To add execute permission for the owner: chmod ___ file.txt | u+x | | u+x adds execute permission for the user/owner.
 FITB | MEDIUM | To remove write permission from group and others: chmod ___ file.txt | go-w | | g=group, o=others, -w removes write.
 FITB | HARD   | What octal permission represents 'rw-r--r--'? | 644 | | r=4, w=2. Owner: 4+2=6, Group: 4, Others: 4.
+
+# ── v2.0 PRAC questions ──────────────────────────────────────
+PRAC | EASY   | Create a file /home/user/script.sh and make it executable by the owner using chmod. | /home/user/script.sh:FILE,/home/user/script.sh:PERM=rwxr--r-- | | Use 'touch script.sh' then 'chmod u+x script.sh' or 'chmod 744 script.sh'.
+PRAC | MEDIUM | Set permissions on /home/user/secret.txt to be readable and writable only by the owner (no group or other access). | /home/user/secret.txt:PERM=rw------- | FILE:/home/user/secret.txt=confidential data | Use 'chmod 600 secret.txt'.
+PRAC | HARD   | Set permissions on all files inside /home/user/project recursively: directories should be rwxr-xr-x and files should be rw-r--r--. Create the directory and a file first. | /home/user/project:DIR,/home/user/project:PERM=rwxr-xr-x,/home/user/project/README.md:FILE | MKDIR:/home/user/project;FILE:/home/user/project/README.md=readme | Use 'chmod -R 755 project/' for dirs, then 'chmod 644 project/README.md'.

--- a/src/main/resources/questions/text-processing.txt
+++ b/src/main/resources/questions/text-processing.txt
@@ -14,3 +14,8 @@ FITB | EASY   | To show the first 5 lines of data.txt: head ___ 5 data.txt | -n 
 FITB | MEDIUM | To count the number of lines in file.txt: wc ___ file.txt | -l | | -l flag counts lines.
 FITB | MEDIUM | To search for 'hello' in file.txt ignoring case: grep ___ hello file.txt | -i | | -i flag makes grep case-insensitive.
 FITB | HARD   | To sort file.txt numerically: sort ___ file.txt | -n | | -n flag enables numeric sorting.
+
+# ── v2.0 PRAC questions ──────────────────────────────────────
+PRAC | EASY   | Create a file called notes.txt inside /home/user/docs. | /home/user/docs:DIR,/home/user/docs/notes.txt:FILE | MKDIR:/home/user/docs | Use 'touch' to create the file after navigating to the directory.
+PRAC | MEDIUM | Using grep and sort, create a file /home/user/result.txt that contains 'hello world'. | /home/user/result.txt:CONTENT_EQUALS=hello world | FILE:/home/user/data.txt=hello world\ngoodbye world\nhello world | Hint: use 'grep hello /home/user/data.txt | sort -u > /home/user/result.txt'.
+PRAC | HARD   | Remove duplicate lines from /home/user/input.txt and save the unique sorted output to /home/user/output.txt. The file should contain: apple\nbanana\ncherry | /home/user/output.txt:CONTENT_EQUALS=apple\nbanana\ncherry | FILE:/home/user/input.txt=cherry\napple\nbanana\napple\ncherry\nbanana | Use 'sort input.txt | uniq > output.txt' to sort and deduplicate.


### PR DESCRIPTION
## Summary

Enhance the exam infrastructure to support richer PRAC questions with new checkpoint types, VFS pre-configuration, and an upgraded question parser.

### Changes
- **Checkpoint**: Add `NOT_EXISTS`, `CONTENT_EQUALS`, `PERM` node types with full constructor
- **PracQuestion**: Add `SetupItem` inner class (`MKDIR`/`FILE`/`PERM`) and `applySetup()` method
- **QuestionParser**: Enhanced PRAC parsing with checkpoint type detection and setup item parsing
- **Question banks**: 6 new PRAC questions (3 text-processing, 3 permissions)

### Files Changed (7)
| File | Change |
|------|--------|
| `Checkpoint.java` | 3 new NodeTypes + full constructor |
| `PracQuestion.java` | SetupItem + applySetup() |
| `QuestionParser.java` | Enhanced PRAC parsing |
| `data/questions/text-processing.txt` | 3 new PRAC questions |
| `data/questions/permissions.txt` | 3 new PRAC questions |
| `src/main/resources/questions/text-processing.txt` | Resource copy |
| `src/main/resources/questions/permissions.txt` | Resource copy |

Closes #59