### PR TITLE
v2.0 New Shell Commands (10 command stubs)

### DIFF
--- a/src/main/java/linuxlingo/shell/CommandRegistry.java
+++ b/src/main/java/linuxlingo/shell/CommandRegistry.java
@@ -5,12 +5,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import linuxlingo.shell.command.AliasCommand;
 import linuxlingo.shell.command.CatCommand;
 import linuxlingo.shell.command.CdCommand;
 import linuxlingo.shell.command.ChmodCommand;
 import linuxlingo.shell.command.ClearCommand;
 import linuxlingo.shell.command.Command;
 import linuxlingo.shell.command.CpCommand;
+import linuxlingo.shell.command.DateCommand;
+import linuxlingo.shell.command.DiffCommand;
 import linuxlingo.shell.command.EchoCommand;
 import linuxlingo.shell.command.EnvDeleteCommand;
 import linuxlingo.shell.command.EnvListCommand;
@@ -18,8 +21,10 @@ import linuxlingo.shell.command.FindCommand;
 import linuxlingo.shell.command.GrepCommand;
 import linuxlingo.shell.command.HeadCommand;
 import linuxlingo.shell.command.HelpCommand;
+import linuxlingo.shell.command.HistoryCommand;
 import linuxlingo.shell.command.LoadCommand;
 import linuxlingo.shell.command.LsCommand;
+import linuxlingo.shell.command.ManCommand;
 import linuxlingo.shell.command.MkdirCommand;
 import linuxlingo.shell.command.MvCommand;
 import linuxlingo.shell.command.PwdCommand;
@@ -28,9 +33,14 @@ import linuxlingo.shell.command.RmCommand;
 import linuxlingo.shell.command.SaveCommand;
 import linuxlingo.shell.command.SortCommand;
 import linuxlingo.shell.command.TailCommand;
+import linuxlingo.shell.command.TeeCommand;
 import linuxlingo.shell.command.TouchCommand;
+import linuxlingo.shell.command.TreeCommand;
+import linuxlingo.shell.command.UnaliasCommand;
 import linuxlingo.shell.command.UniqCommand;
 import linuxlingo.shell.command.WcCommand;
+import linuxlingo.shell.command.WhichCommand;
+import linuxlingo.shell.command.WhoamiCommand;
 
 /**
  * Registry that maps command name strings to {@link Command} instances.
@@ -81,6 +91,18 @@ public final class CommandRegistry {
         register("reset", new ResetCommand());
         register("envlist", new EnvListCommand());
         register("envdelete", new EnvDeleteCommand());
+
+        // ── v2.0 — New Commands (Owner: C) ───────────────────────
+        register("man", new ManCommand());
+        register("tree", new TreeCommand());
+        register("which", new WhichCommand());
+        register("whoami", new WhoamiCommand());
+        register("date", new DateCommand());
+        register("alias", new AliasCommand());
+        register("unalias", new UnaliasCommand());
+        register("tee", new TeeCommand());
+        register("diff", new DiffCommand());
+        register("history", new HistoryCommand());
     }
 
     public void register(String name, Command cmd) {

--- a/src/main/java/linuxlingo/shell/command/AliasCommand.java
+++ b/src/main/java/linuxlingo/shell/command/AliasCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Create or display shell aliases.
+ * Supports: alias [name=value]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class AliasCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement AliasCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "alias [name=value]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Create or display shell aliases";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/DateCommand.java
+++ b/src/main/java/linuxlingo/shell/command/DateCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Print the current date and time.
+ * Supports: date
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class DateCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement DateCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "date";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Print the current date and time";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/DiffCommand.java
+++ b/src/main/java/linuxlingo/shell/command/DiffCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Compare two files line by line.
+ * Supports: diff &lt;file1&gt; &lt;file2&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class DiffCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement DiffCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "diff <file1> <file2>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Compare two files line by line";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/HistoryCommand.java
+++ b/src/main/java/linuxlingo/shell/command/HistoryCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display or manage command history.
+ * Supports: history [-c] [N]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class HistoryCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement HistoryCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "history [-c] [N]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display or manage command history";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/ManCommand.java
+++ b/src/main/java/linuxlingo/shell/command/ManCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display the manual page for a command.
+ * Supports: man &lt;command&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class ManCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement ManCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "man <command>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display the manual page for a command";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/TeeCommand.java
+++ b/src/main/java/linuxlingo/shell/command/TeeCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Read from stdin and write to both stdout and a file.
+ * Supports: tee [-a] &lt;file&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class TeeCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement TeeCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "tee [-a] <file>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Read from stdin and write to both stdout and a file";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/TreeCommand.java
+++ b/src/main/java/linuxlingo/shell/command/TreeCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display a directory tree structure.
+ * Supports: tree [path]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class TreeCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement TreeCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "tree [path]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display a directory tree structure";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/UnaliasCommand.java
+++ b/src/main/java/linuxlingo/shell/command/UnaliasCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Remove shell aliases.
+ * Supports: unalias [-a] &lt;name&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class UnaliasCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement UnaliasCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "unalias [-a] <name>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove shell aliases";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/WhichCommand.java
+++ b/src/main/java/linuxlingo/shell/command/WhichCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Show the path of a command.
+ * Supports: which &lt;command&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class WhichCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement WhichCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "which <command>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Show the path of a command";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/WhoamiCommand.java
+++ b/src/main/java/linuxlingo/shell/command/WhoamiCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Print the current user name.
+ * Supports: whoami
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class WhoamiCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement WhoamiCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "whoami";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Print the current user name";
+    }
+}


### PR DESCRIPTION
## Summary

Add 10 new shell command stubs and register them in CommandRegistry. Each has `getUsage()` and `getDescription()` implemented, with `execute()` as a placeholder for Member C to complete.

### New Commands
| Command | Description |
|---------|-------------|
| `ManCommand` | Display command manual page |
| `TreeCommand` | Display directory tree |
| `WhichCommand` | Show if command exists |
| `WhoamiCommand` | Print current username |
| `DateCommand` | Print current date/time |
| `AliasCommand` | Set/list command aliases |
| `UnaliasCommand` | Remove command alias |
| `TeeCommand` | Read stdin, write to file(s) and stdout |
| `DiffCommand` | Compare two files |
| `HistoryCommand` | Show command history |

### Files Changed (11)
- 10 new command stub files in `shell/command/`
- `CommandRegistry.java` — register all 10 new commands

Relates to #60