### PR TITLE
v2.0 New Shell Commands (Member C)

### DIFF
--- a/src/main/java/linuxlingo/shell/command/AliasCommand.java
+++ b/src/main/java/linuxlingo/shell/command/AliasCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Create or display shell aliases.
+ * Supports: alias [name=value]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class AliasCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement AliasCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "alias [name=value]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Create or display shell aliases";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/DateCommand.java
+++ b/src/main/java/linuxlingo/shell/command/DateCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Print the current date and time.
+ * Supports: date
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class DateCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement DateCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "date";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Print the current date and time";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/DiffCommand.java
+++ b/src/main/java/linuxlingo/shell/command/DiffCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Compare two files line by line.
+ * Supports: diff &lt;file1&gt; &lt;file2&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class DiffCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement DiffCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "diff <file1> <file2>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Compare two files line by line";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/HistoryCommand.java
+++ b/src/main/java/linuxlingo/shell/command/HistoryCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display or manage command history.
+ * Supports: history [-c] [N]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class HistoryCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement HistoryCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "history [-c] [N]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display or manage command history";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/ManCommand.java
+++ b/src/main/java/linuxlingo/shell/command/ManCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display the manual page for a command.
+ * Supports: man &lt;command&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class ManCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement ManCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "man <command>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display the manual page for a command";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/TeeCommand.java
+++ b/src/main/java/linuxlingo/shell/command/TeeCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Read from stdin and write to both stdout and a file.
+ * Supports: tee [-a] &lt;file&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class TeeCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement TeeCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "tee [-a] <file>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Read from stdin and write to both stdout and a file";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/TreeCommand.java
+++ b/src/main/java/linuxlingo/shell/command/TreeCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Display a directory tree structure.
+ * Supports: tree [path]
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class TreeCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement TreeCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "tree [path]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display a directory tree structure";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/UnaliasCommand.java
+++ b/src/main/java/linuxlingo/shell/command/UnaliasCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Remove shell aliases.
+ * Supports: unalias [-a] &lt;name&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class UnaliasCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement UnaliasCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "unalias [-a] <name>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove shell aliases";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/WhichCommand.java
+++ b/src/main/java/linuxlingo/shell/command/WhichCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Show the path of a command.
+ * Supports: which &lt;command&gt;
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class WhichCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement WhichCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "which <command>";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Show the path of a command";
+    }
+}

--- a/src/main/java/linuxlingo/shell/command/WhoamiCommand.java
+++ b/src/main/java/linuxlingo/shell/command/WhoamiCommand.java
@@ -1,0 +1,27 @@
+package linuxlingo.shell.command;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+
+/**
+ * Print the current user name.
+ * Supports: whoami
+ *
+ * <p><b>@Owner: C</b></p>
+ */
+public class WhoamiCommand implements Command {
+    @Override
+    public CommandResult execute(ShellSession session, String[] args, String stdin) {
+        throw new UnsupportedOperationException("TODO: Member C — implement WhoamiCommand");
+    }
+
+    @Override
+    public String getUsage() {
+        return "whoami";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Print the current user name";
+    }
+}

--- a/src/test/java/linuxlingo/shell/command/HistoryCommandTest.java
+++ b/src/test/java/linuxlingo/shell/command/HistoryCommandTest.java
@@ -1,0 +1,209 @@
+package linuxlingo.shell.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+import linuxlingo.shell.vfs.VirtualFileSystem;
+
+/**
+ * Tests for the history command and ShellSession command history tracking.
+ */
+public class HistoryCommandTest {
+    private HistoryCommand command;
+    private ShellSession session;
+
+    @BeforeEach
+    public void setUp() {
+        VirtualFileSystem vfs = new VirtualFileSystem();
+        session = new ShellSession(vfs, null);
+        command = new HistoryCommand();
+    }
+
+    @Nested
+    class BasicHistory {
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void emptyHistory_returnsEmpty() {
+            CommandResult result = command.execute(session,
+                    new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void singleEntry_displaysNumbered() {
+            session.getCommandHistory().add("ls -la");
+            CommandResult result = command.execute(session,
+                    new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("1"));
+            assertTrue(result.getStdout().contains("ls -la"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void multipleEntries_displaysAllNumbered() {
+            session.getCommandHistory().add("cd /tmp");
+            session.getCommandHistory().add("ls");
+            session.getCommandHistory().add("cat file.txt");
+
+            CommandResult result = command.execute(session,
+                    new String[]{}, null);
+            assertTrue(result.isSuccess());
+            String output = result.getStdout();
+            assertTrue(output.contains("1"));
+            assertTrue(output.contains("cd /tmp"));
+            assertTrue(output.contains("2"));
+            assertTrue(output.contains("ls"));
+            assertTrue(output.contains("3"));
+            assertTrue(output.contains("cat file.txt"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void historyFormat_hasLineNumbers() {
+            session.getCommandHistory().add("pwd");
+            CommandResult result = command.execute(session,
+                    new String[]{}, null);
+            // Format: "    1  pwd"
+            assertTrue(result.getStdout().matches("\\s+1\\s+pwd"));
+        }
+    }
+
+    @Nested
+    class HistoryLimit {
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void limitN_showsLastNEntries() {
+            session.getCommandHistory().add("cmd1");
+            session.getCommandHistory().add("cmd2");
+            session.getCommandHistory().add("cmd3");
+            session.getCommandHistory().add("cmd4");
+            session.getCommandHistory().add("cmd5");
+
+            CommandResult result = command.execute(session,
+                    new String[]{"3"}, null);
+            assertTrue(result.isSuccess());
+            String output = result.getStdout();
+            assertFalse(output.contains("cmd1"));
+            assertFalse(output.contains("cmd2"));
+            assertTrue(output.contains("cmd3"));
+            assertTrue(output.contains("cmd4"));
+            assertTrue(output.contains("cmd5"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void limitZero_showsNothing() {
+            session.getCommandHistory().add("cmd1");
+            CommandResult result = command.execute(session,
+                    new String[]{"0"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void limitLargerThanHistory_showsAll() {
+            session.getCommandHistory().add("cmd1");
+            session.getCommandHistory().add("cmd2");
+
+            CommandResult result = command.execute(session,
+                    new String[]{"100"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("cmd1"));
+            assertTrue(result.getStdout().contains("cmd2"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void negativeLimit_returnsError() {
+            CommandResult result = command.execute(session,
+                    new String[]{"-5"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("invalid option"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void nonNumericArg_returnsError() {
+            CommandResult result = command.execute(session,
+                    new String[]{"abc"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("numeric argument"));
+        }
+    }
+
+    @Nested
+    class HistoryClear {
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void clearFlag_emptiesHistory() {
+            session.getCommandHistory().add("cmd1");
+            session.getCommandHistory().add("cmd2");
+
+            CommandResult result = command.execute(session,
+                    new String[]{"-c"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals(0, session.getCommandHistory().size());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void clearEmpty_succeeds() {
+            CommandResult result = command.execute(session,
+                    new String[]{"-c"}, null);
+            assertTrue(result.isSuccess());
+        }
+    }
+
+    @Nested
+    class CommandMetadata {
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void getUsage_notEmpty() {
+            assertFalse(command.getUsage().isEmpty());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void getDescription_notEmpty() {
+            assertFalse(command.getDescription().isEmpty());
+        }
+    }
+
+    @Nested
+    class SessionHistoryTracking {
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void executeOnce_doesNotAddToHistory() {
+            // executeOnce is for programmatic use, should NOT track
+            session.executeOnce("ls");
+            assertEquals(0, session.getCommandHistory().size());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void commandHistory_initiallyEmpty() {
+            assertTrue(session.getCommandHistory().isEmpty());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement HistoryCommand first")
+        public void commandHistory_addAndRetrieve() {
+            session.getCommandHistory().add("ls -la");
+            session.getCommandHistory().add("pwd");
+            assertEquals(2, session.getCommandHistory().size());
+            assertEquals("ls -la", session.getCommandHistory().get(0));
+            assertEquals("pwd", session.getCommandHistory().get(1));
+        }
+    }
+}

--- a/src/test/java/linuxlingo/shell/command/NewCommandsV2Test.java
+++ b/src/test/java/linuxlingo/shell/command/NewCommandsV2Test.java
@@ -1,0 +1,391 @@
+package linuxlingo.shell.command;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import linuxlingo.cli.Ui;
+import linuxlingo.shell.CommandResult;
+import linuxlingo.shell.ShellSession;
+import linuxlingo.shell.vfs.VirtualFileSystem;
+
+/**
+ * Tests for all v2.0 new commands:
+ * man, tree, which, whoami, date, alias, unalias, tee, diff.
+ */
+public class NewCommandsV2Test {
+    private ShellSession session;
+    private VirtualFileSystem vfs;
+
+    @BeforeEach
+    public void setUp() {
+        vfs = new VirtualFileSystem();
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outStream);
+        Ui ui = new Ui(new ByteArrayInputStream(new byte[0]), out);
+        session = new ShellSession(vfs, ui);
+        session.setWorkingDir("/home/user");
+    }
+
+    // ─── ManCommand ──────────────────────────────────────────────
+
+    @Nested
+    class ManTests {
+        private ManCommand command = new ManCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void man_knownCommand_showsManPage() {
+            CommandResult result = command.execute(session, new String[]{"ls"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("NAME"));
+            assertTrue(result.getStdout().contains("SYNOPSIS"));
+            assertTrue(result.getStdout().contains("DESCRIPTION"));
+            assertTrue(result.getStdout().contains("ls"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void man_unknownCommand_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"fakecmd"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("no manual entry"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void man_noArgs_returnsError() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertFalse(result.isSuccess());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void man_usageAndDescription_areValid() {
+            assertTrue(command.getUsage().contains("man"));
+            assertFalse(command.getDescription().isEmpty());
+        }
+    }
+
+    // ─── TreeCommand ────────────────────────────────────────────
+
+    @Nested
+    class TreeTests {
+        private TreeCommand command = new TreeCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tree_defaultDir_showsTree() {
+            // Create some structure
+            vfs.createDirectory("/home/user/project", "/", true);
+            vfs.createFile("/home/user/project/README.md", "/");
+            session.setWorkingDir("/home/user");
+
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("project"));
+            assertTrue(result.getStdout().contains("README.md"));
+            assertTrue(result.getStdout().contains("director"));
+            assertTrue(result.getStdout().contains("file"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tree_specificPath_showsTree() {
+            vfs.createDirectory("/tmp/a", "/", true);
+            vfs.createFile("/tmp/a/b.txt", "/");
+
+            CommandResult result = command.execute(session, new String[]{"/tmp"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("a"));
+            assertTrue(result.getStdout().contains("b.txt"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tree_emptyDir_showsNoItems() {
+            vfs.createDirectory("/home/user/empty", "/", true);
+            CommandResult result = command.execute(session, new String[]{"/home/user/empty"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("0 director"));
+            assertTrue(result.getStdout().contains("0 file"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tree_invalidPath_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"/nonexistent"}, null);
+            assertFalse(result.isSuccess());
+        }
+    }
+
+    // ─── WhichCommand ───────────────────────────────────────────
+
+    @Nested
+    class WhichTests {
+        private WhichCommand command = new WhichCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void which_knownCommand_showsPath() {
+            CommandResult result = command.execute(session, new String[]{"ls"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("/usr/bin/ls", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void which_unknownCommand_returnsNotFound() {
+            CommandResult result = command.execute(session, new String[]{"fakecmd"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("not found"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void which_noArgs_returnsError() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertFalse(result.isSuccess());
+        }
+    }
+
+    // ─── WhoamiCommand ──────────────────────────────────────────
+
+    @Nested
+    class WhoamiTests {
+        private WhoamiCommand command = new WhoamiCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void whoami_returnsUser() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("user", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void whoami_withArgs_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"extra"}, null);
+            assertFalse(result.isSuccess());
+        }
+    }
+
+    // ─── DateCommand ────────────────────────────────────────────
+
+    @Nested
+    class DateTests {
+        private DateCommand command = new DateCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void date_returnsFormattedDate() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertTrue(result.isSuccess());
+            // Should contain a year number
+            assertTrue(result.getStdout().matches(".*\\d{4}.*"));
+        }
+    }
+
+    // ─── AliasCommand ───────────────────────────────────────────
+
+    @Nested
+    class AliasTests {
+        private AliasCommand command = new AliasCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_noArgs_listsEmpty() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_setAlias_storesCorrectly() {
+            CommandResult result = command.execute(session, new String[]{"ll=ls -la"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("ls -la", session.getAliases().get("ll"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_setMultipleAliases_listsAll() {
+            command.execute(session, new String[]{"ll=ls -la"}, null);
+            command.execute(session, new String[]{"c=clear"}, null);
+
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("ll='ls -la'"));
+            assertTrue(result.getStdout().contains("c='clear'"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_lookupSingle_showsValue() {
+            command.execute(session, new String[]{"ll=ls -la"}, null);
+            CommandResult result = command.execute(session, new String[]{"ll"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("ll='ls -la'"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_lookupUnknown_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"unknown"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("not found"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void alias_withQuotedValue_stripsQuotes() {
+            command.execute(session, new String[]{"g='grep -i'"}, null);
+            assertEquals("grep -i", session.getAliases().get("g"));
+        }
+    }
+
+    // ─── UnaliasCommand ─────────────────────────────────────────
+
+    @Nested
+    class UnaliasTests {
+        private UnaliasCommand command = new UnaliasCommand();
+        private AliasCommand aliasCmd = new AliasCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void unalias_removesExisting() {
+            aliasCmd.execute(session, new String[]{"ll=ls -la"}, null);
+            CommandResult result = command.execute(session, new String[]{"ll"}, null);
+            assertTrue(result.isSuccess());
+            assertFalse(session.getAliases().containsKey("ll"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void unalias_nonExisting_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"nope"}, null);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getStderr().contains("not found"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void unalias_dashA_clearsAll() {
+            aliasCmd.execute(session, new String[]{"a=b"}, null);
+            aliasCmd.execute(session, new String[]{"c=d"}, null);
+            CommandResult result = command.execute(session, new String[]{"-a"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(session.getAliases().isEmpty());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void unalias_noArgs_returnsError() {
+            CommandResult result = command.execute(session, new String[]{}, null);
+            assertFalse(result.isSuccess());
+        }
+    }
+
+    // ─── TeeCommand ────────────────────────────────────────────
+
+    @Nested
+    class TeeTests {
+        private TeeCommand command = new TeeCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tee_writesStdinToFileAndStdout() {
+            CommandResult result = command.execute(session, new String[]{"output.txt"}, "hello world");
+            assertTrue(result.isSuccess());
+            assertEquals("hello world", result.getStdout());
+            assertEquals("hello world", vfs.readFile("/home/user/output.txt", "/"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tee_appendMode_appendsContent() {
+            vfs.createFile("/home/user/log.txt", "/");
+            vfs.writeFile("/home/user/log.txt", "/", "line1\n", false);
+
+            CommandResult result = command.execute(session, new String[]{"-a", "log.txt"}, "line2");
+            assertTrue(result.isSuccess());
+            assertTrue(vfs.readFile("/home/user/log.txt", "/").contains("line1"));
+            assertTrue(vfs.readFile("/home/user/log.txt", "/").contains("line2"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tee_noStdin_returnsEmpty() {
+            CommandResult result = command.execute(session, new String[]{"out.txt"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void tee_noArgs_returnsError() {
+            CommandResult result = command.execute(session, new String[]{}, "data");
+            assertFalse(result.isSuccess());
+        }
+    }
+
+    // ─── DiffCommand ────────────────────────────────────────────
+
+    @Nested
+    class DiffTests {
+        private DiffCommand command = new DiffCommand();
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void diff_identicalFiles_returnsEmpty() {
+            vfs.createFile("/home/user/a.txt", "/");
+            vfs.createFile("/home/user/b.txt", "/");
+            vfs.writeFile("/home/user/a.txt", "/", "same content", false);
+            vfs.writeFile("/home/user/b.txt", "/", "same content", false);
+
+            CommandResult result = command.execute(session, new String[]{"a.txt", "b.txt"}, null);
+            assertTrue(result.isSuccess());
+            assertEquals("", result.getStdout());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void diff_differentFiles_showsDiff() {
+            vfs.createFile("/home/user/a.txt", "/");
+            vfs.createFile("/home/user/b.txt", "/");
+            vfs.writeFile("/home/user/a.txt", "/", "line1\nline2", false);
+            vfs.writeFile("/home/user/b.txt", "/", "line1\nline3", false);
+
+            CommandResult result = command.execute(session, new String[]{"a.txt", "b.txt"}, null);
+            assertTrue(result.isSuccess());
+            assertTrue(result.getStdout().contains("<") || result.getStdout().contains(">"));
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void diff_missingFile_returnsError() {
+            vfs.createFile("/home/user/a.txt", "/");
+            vfs.writeFile("/home/user/a.txt", "/", "content", false);
+
+            CommandResult result = command.execute(session, new String[]{"a.txt", "nonexistent.txt"}, null);
+            assertFalse(result.isSuccess());
+        }
+
+        @Test
+        @Disabled("TODO: Member C — implement command first")
+        public void diff_wrongArgCount_returnsError() {
+            CommandResult result = command.execute(session, new String[]{"only_one.txt"}, null);
+            assertFalse(result.isSuccess());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add 10 new shell command stubs for Member C to implement, plus 50 `@Disabled` placeholder tests.

### New Command Stubs (10 files)

| Command | File | Description |
|---------|------|-------------|
| `man` | `ManCommand.java` | Display command manual page |
| `tree` | `TreeCommand.java` | Display directory tree |
| `which` | `WhichCommand.java` | Show if command exists in registry |
| `whoami` | `WhoamiCommand.java` | Print current username |
| `date` | `DateCommand.java` | Print current date/time |
| `alias` | `AliasCommand.java` | Set/list command aliases |
| `unalias` | `UnaliasCommand.java` | Remove command alias |
| `tee` | `TeeCommand.java` | Read stdin, write to file(s) and stdout |
| `diff` | `DiffCommand.java` | Compare two files line-by-line |
| `history` | `HistoryCommand.java` | Show command history |

Each stub has `getUsage()` + `getDescription()` implemented. `execute()` throws `UnsupportedOperationException` until Member C completes it.

### Placeholder Tests (2 files, 50 @Disabled tests)

| File | Count | Enable When |
|------|-------|-------------|
| `NewCommandsV2Test.java` | 30 | After implementing each command |
| `HistoryCommandTest.java` | 20 | After implementing `HistoryCommand` |

Closes #70