### PR TITLE
Add ShellParser and ShellSession implementation details to Developer Guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -603,6 +603,13 @@ SS -> VFS : writeFile("output.txt", workingDir, "hello", false)
 @enduml
 ```
 
+When a command name is not found in the registry, `runPlan()` calls `suggestCommand()`
+before printing the error. This method computes the Levenshtein edit distance between
+the mistyped input and every registered command name, returning a "Did you mean 'X'?"
+hint if the closest match is within distance 2. Glob patterns in arguments (containing
+`*` or `?`) are expanded against the VFS via `expandGlobs()` before the command receives
+them — if no VFS paths match the pattern, the literal argument is passed through unchanged.
+
 **Operator semantics:**
 
 | Operator | Symbol | Behavior |


### PR DESCRIPTION
Documents two areas of the Shell component implementation for future developers:

- ShellParser: tokenizer lookahead for multi-char operators (||, >>), 
  lone & handling, and redirect-expect state reset on malformed input
- ShellSession: how unrecognised commands trigger a nearest-match suggestion,
  and how wildcard arguments are expanded against the VFS before execution