### PR TITLE
Test report and partial bug fixes

### DIFF
--- a/docs/test_reports/Purav_TestReport.md
+++ b/docs/test_reports/Purav_TestReport.md
@@ -1,0 +1,34 @@
+# Test Report — Purav (Exam Module)
+
+### invalid input in MCQ questions (eg. typing the answer instead of A, B, C, D or empty input) - FIXED
+
+*expected*: error message prompting user to input a valid option (A, B, C, D)
+*actual*: the answer is marked as incorrect, and the user receives feedback on the correct answer. No error message is shown for invalid input.
+
+### No explanation provided for FITB and PRAC questions - FIXED
+
+### inputting invalid topic while topic selection (eg. 8 or typo in topic name) - FIXED
+
+*expected* error message prompting user to select a valid topic
+*actual* command exits and you have to type in exam again
+
+### Using quit on PRAC question does not work
+
+Maybe it should be mentioned in the UG that quit only works for mcq and fitb
+
+### using quit when on exam -random simply skips the question without any output like showing score 0/1 incorrect or skipped - FIXED
+
+### exam -t navigation -t file-management (duplicate topics)
+
+starts an exam with all question from the latest topic mentioned
+
+*expected* error message prompting user to enter command in proper format
+
+### exam command with unknown or empty flags (eg: exam -topic navigation or exam -t)
+
+*expected* error message prompting user to enter command in proper format
+*actual* exam session is started, prompting user to select topic and unknown flag is ignored
+
+
+
+

--- a/src/main/java/linuxlingo/exam/ExamSession.java
+++ b/src/main/java/linuxlingo/exam/ExamSession.java
@@ -83,35 +83,44 @@ public class ExamSession {
      * Prompt the user to choose a topic, either by number or by name.
      *
      * @param topics the list of available topics
-     * @return the selected topic name, or {@code null} if selection was invalid
+     * @return the selected topic name, or {@code null} if the input stream ends
      */
     private String promptForTopic(List<String> topics) {
-        listTopics();
-        String topicInput = ui.readLine("Select topic (number or name): ");
-        if (topicInput == null) {
-            LOGGER.fine("Topic selection input was null");
-            ui.println("Invalid topic selection.");
-            return null;
-        }
-
-        String selectedTopic = null;
-        String trimmedTopicInput = topicInput.trim();
-        try {
-            int index = Integer.parseInt(trimmedTopicInput);
-            if (index >= 1 && index <= topics.size()) {
-                selectedTopic = topics.get(index - 1);
+        while (true) {
+            listTopics();
+            String topicInput = ui.readLine("Select topic (number or name): ");
+            if (topicInput == null) {
+                // Input stream ended (e.g. tests with insufficient input).
+                LOGGER.fine("Topic selection input was null (input stream ended?)");
+                ui.println("Invalid topic selection.");
+                return null;
             }
-        } catch (NumberFormatException e) {
-            if (questionBank.hasTopic(trimmedTopicInput)) {
-                selectedTopic = trimmedTopicInput;
-            }
-        }
 
-        if (selectedTopic == null) {
+            String trimmedTopicInput = topicInput.trim();
+            if (trimmedTopicInput.isEmpty()) {
+                ui.println("Invalid topic selection. Please enter a topic number or name.");
+                continue;
+            }
+
+            String selectedTopic = null;
+            try {
+                int index = Integer.parseInt(trimmedTopicInput);
+                if (index >= 1 && index <= topics.size()) {
+                    selectedTopic = topics.get(index - 1);
+                }
+            } catch (NumberFormatException e) {
+                if (questionBank.hasTopic(trimmedTopicInput)) {
+                    selectedTopic = trimmedTopicInput;
+                }
+            }
+
+            if (selectedTopic != null) {
+                return selectedTopic;
+            }
+
             LOGGER.log(Level.INFO, "Invalid interactive topic selection: {0}", trimmedTopicInput);
-            ui.println("Invalid topic selection.");
+            ui.println("Invalid topic selection. Please choose one of the topics listed.");
         }
-        return selectedTopic;
     }
 
     /**

--- a/src/main/java/linuxlingo/exam/QuestionInteraction.java
+++ b/src/main/java/linuxlingo/exam/QuestionInteraction.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import linuxlingo.cli.Ui;
+import linuxlingo.exam.question.McqQuestion;
 import linuxlingo.exam.question.Question;
 
 /**
@@ -33,6 +34,46 @@ class QuestionInteraction {
     }
 
     /**
+     * Reads an MCQ response and validates that it is one of A/B/C/D.
+     * Keeps prompting until the user enters a valid option, or types quit/abort.
+     *
+     * @return normalized answer ("A"/"B"/"C"/"D"), or a raw command ("quit"/"abort"),
+     *     or {@code null} if the UI returns null.
+     */
+    private String askValidatedMcqAnswer(McqQuestion question, int index, int total) {
+        ui.println("[Q" + index + "/" + total + "] " + question.present());
+        while (true) {
+            String userAnswer = ui.readLine("Your answer: ");
+            if (userAnswer == null) {
+                return null;
+            }
+
+            String trimmed = userAnswer.trim();
+            if (trimmed.equalsIgnoreCase("quit") || trimmed.equalsIgnoreCase("abort")) {
+                return trimmed;
+            }
+
+            if (trimmed.isEmpty()) {
+                ui.println("Invalid input. Please enter A, B, C, or D.");
+                continue;
+            }
+
+            if (trimmed.length() != 1) {
+                ui.println("Invalid input. Please enter A, B, C, or D.");
+                continue;
+            }
+
+            char c = Character.toUpperCase(trimmed.charAt(0));
+            if (c < 'A' || c > 'D') {
+                ui.println("Invalid input. Please enter A, B, C, or D.");
+                continue;
+            }
+
+            return String.valueOf(c);
+        }
+    }
+
+    /**
      * Present a non-PRAC question as part of an exam run and record the
      * result in the given {@link ExamResult}.
      */
@@ -40,7 +81,13 @@ class QuestionInteraction {
         Objects.requireNonNull(question, "question must not be null");
         Objects.requireNonNull(result, "result must not be null");
 
-        String userAnswer = askQuestion(question, index, total);
+        String userAnswer;
+        if (question instanceof McqQuestion) {
+            userAnswer = askValidatedMcqAnswer((McqQuestion) question, index, total);
+        } else {
+            userAnswer = askQuestion(question, index, total);
+        }
+
         if (userAnswer != null && userAnswer.trim().equalsIgnoreCase("abort")) {
             examAborted = true;
             ui.println("Exam aborted.");
@@ -75,7 +122,12 @@ class QuestionInteraction {
             throw new IllegalArgumentException("index and total must be positive");
         }
 
-        String userAnswer = askQuestion(question, index, total);
+        String userAnswer;
+        if (question instanceof McqQuestion) {
+            userAnswer = askValidatedMcqAnswer((McqQuestion) question, index, total);
+        } else {
+            userAnswer = askQuestion(question, index, total);
+        }
         if (userAnswer == null || userAnswer.trim().equalsIgnoreCase("quit")) {
             LOGGER.log(Level.FINE, "Question skipped by user at index {0}", index);
             return false;

--- a/src/main/java/linuxlingo/exam/QuestionInteraction.java
+++ b/src/main/java/linuxlingo/exam/QuestionInteraction.java
@@ -164,6 +164,7 @@ class QuestionInteraction {
         }
         if (userAnswer == null || userAnswer.trim().equalsIgnoreCase("quit")) {
             LOGGER.log(Level.FINE, "Question skipped by user at index {0}", index);
+            ui.println("Skipped.");
             return false;
         }
 

--- a/src/main/java/linuxlingo/exam/QuestionInteraction.java
+++ b/src/main/java/linuxlingo/exam/QuestionInteraction.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import linuxlingo.cli.Ui;
+import linuxlingo.exam.question.FitbQuestion;
 import linuxlingo.exam.question.McqQuestion;
 import linuxlingo.exam.question.Question;
 
@@ -31,6 +32,35 @@ class QuestionInteraction {
     private String askQuestion(Question question, int index, int total) {
         ui.println("[Q" + index + "/" + total + "] " + question.present());
         return ui.readLine("Your answer: ");
+    }
+
+    /**
+     * Reads a FITB response and rejects empty input.
+     * Prints the question once, then re-prompts only for the answer.
+     *
+     * @return user answer (may contain spaces), or a raw command ("quit"/"abort"),
+     *     or {@code null} if the UI returns null.
+     */
+    private String askValidatedFitbAnswer(FitbQuestion question, int index, int total) {
+        ui.println("[Q" + index + "/" + total + "] " + question.present());
+        while (true) {
+            String userAnswer = ui.readLine("Your answer: ");
+            if (userAnswer == null) {
+                return null;
+            }
+
+            String trimmed = userAnswer.trim();
+            if (trimmed.equalsIgnoreCase("quit") || trimmed.equalsIgnoreCase("abort")) {
+                return trimmed;
+            }
+
+            if (trimmed.isEmpty()) {
+                ui.println("Invalid input. Please enter a non-empty answer.");
+                continue;
+            }
+
+            return userAnswer;
+        }
     }
 
     /**
@@ -84,6 +114,8 @@ class QuestionInteraction {
         String userAnswer;
         if (question instanceof McqQuestion) {
             userAnswer = askValidatedMcqAnswer((McqQuestion) question, index, total);
+        } else if (question instanceof FitbQuestion) {
+            userAnswer = askValidatedFitbAnswer((FitbQuestion) question, index, total);
         } else {
             userAnswer = askQuestion(question, index, total);
         }
@@ -125,6 +157,8 @@ class QuestionInteraction {
         String userAnswer;
         if (question instanceof McqQuestion) {
             userAnswer = askValidatedMcqAnswer((McqQuestion) question, index, total);
+        } else if (question instanceof FitbQuestion) {
+            userAnswer = askValidatedFitbAnswer((FitbQuestion) question, index, total);
         } else {
             userAnswer = askQuestion(question, index, total);
         }

--- a/src/main/java/linuxlingo/exam/question/McqQuestion.java
+++ b/src/main/java/linuxlingo/exam/question/McqQuestion.java
@@ -41,10 +41,21 @@ public class McqQuestion extends Question {
 
     @Override
     public boolean checkAnswer(String answer) {
-        if (answer == null || answer.trim().isEmpty()) {
+        if (answer == null) {
             return false;
         }
-        return Character.toUpperCase(answer.trim().charAt(0)) == correctAnswer;
+
+        String trimmed = answer.trim();
+        if (trimmed.length() != 1) {
+            return false;
+        }
+
+        char letter = Character.toUpperCase(trimmed.charAt(0));
+        if (letter < 'A' || letter > 'D') {
+            return false;
+        }
+
+        return letter == correctAnswer;
     }
 
     public char getCorrectAnswer() {

--- a/src/main/java/linuxlingo/storage/QuestionParser.java
+++ b/src/main/java/linuxlingo/storage/QuestionParser.java
@@ -48,6 +48,16 @@ import linuxlingo.exam.question.Question;
 public class QuestionParser {
     private static final Logger LOGGER = Logger.getLogger(QuestionParser.class.getName());
 
+    // Question bank schema: TYPE | DIFFICULTY | QUESTION_TEXT | ANSWER | OPTIONS | EXPLANATION
+    private static final int FIELD_COUNT = 6;
+
+    private static final int IDX_TYPE = 0;
+    private static final int IDX_DIFFICULTY = 1;
+    private static final int IDX_QUESTION_TEXT = 2;
+    private static final int IDX_ANSWER = 3;
+    private static final int IDX_OPTIONS = 4;
+    private static final int IDX_EXPLANATION = 5;
+
     /**
      * Parse a single question bank file into a list of questions.
      *
@@ -67,19 +77,37 @@ public class QuestionParser {
                 continue;
             }
 
-            String[] fields = trimmedLine.split("\\s+\\|\\s+", 6);
-            if (fields.length < 4) {
+            String[] rawFields = trimmedLine.split("\\s+\\|\\s+", -1);
+
+            if (rawFields.length < 4 || rawFields.length > FIELD_COUNT) {
                 LOGGER.log(Level.WARNING, "Skipping malformed question line {0} in {1}",
                         new Object[]{i + 1, validatedPath});
                 continue;
             }
 
-            String type = fields[0].trim().toUpperCase(Locale.ROOT);
-            Question.Difficulty difficulty = parseDifficulty(fields[1].trim());
-            String questionText = fields[2].trim();
-            String answer = fields[3].trim();
-            String options = fields.length >= 5 ? fields[4].trim() : "";
-            String explanation = fields.length >= 6 ? fields[5].trim() : "";
+            if (rawFields.length < FIELD_COUNT) {
+                String[] padded = new String[FIELD_COUNT];
+                System.arraycopy(rawFields, 0, padded, 0, rawFields.length);
+                for (int j = rawFields.length; j < FIELD_COUNT; j++) {
+                    padded[j] = "";
+                }
+                rawFields = padded;
+            }
+            String type = rawFields[IDX_TYPE].trim().toUpperCase(Locale.ROOT);
+            Question.Difficulty difficulty = parseDifficulty(rawFields[IDX_DIFFICULTY].trim());
+            String questionText = rawFields[IDX_QUESTION_TEXT].trim();
+            String answer = rawFields[IDX_ANSWER].trim();
+            String options = rawFields[IDX_OPTIONS].trim();
+            String explanation = rawFields[IDX_EXPLANATION].trim();
+
+            if (!"MCQ".equals(type) && options.isEmpty() && !explanation.isEmpty()) {
+            } else if (!"MCQ".equals(type) && !options.isEmpty() && explanation.isEmpty()) {
+                explanation = options;
+                options = "";
+            }
+            if (explanation.startsWith("|")) {
+                explanation = explanation.substring(1).trim();
+            }
 
             try {
                 switch (type) {
@@ -149,11 +177,9 @@ public class QuestionParser {
      */
     private static FitbQuestion parseFitb(String questionText, String answer,
                                           String explanation, Question.Difficulty difficulty) {
-        // Split by unescaped pipe: use negative lookbehind so \| is not treated as separator
         String[] answers = answer.split("(?<!\\\\)\\|");
         List<String> accepted = new ArrayList<>();
         for (String acceptedAnswer : answers) {
-            // Unescape \| to literal |
             String trimmedAnswer = acceptedAnswer.trim().replace("\\|", "|");
             if (!trimmedAnswer.isEmpty()) {
                 accepted.add(trimmedAnswer);
@@ -191,7 +217,6 @@ public class QuestionParser {
             throw new IllegalArgumentException("PRAC checkpoints must not be empty");
         }
 
-        // v2.0: parse setup items from 'options' field (semicolon-separated).
         List<SetupItem> setupItems = new ArrayList<>();
         if (options != null && !options.trim().isEmpty()) {
             String[] rawItems = options.split(";");

--- a/src/test/java/linuxlingo/exam/ExamSessionTest.java
+++ b/src/test/java/linuxlingo/exam/ExamSessionTest.java
@@ -79,11 +79,14 @@ public class ExamSessionTest {
     }
 
     @Test
-    public void startInteractive_invalidTopicNumber_printsError() throws Exception {
+    public void startInteractive_invalidTopicNumber_printsErrorAndReprompts() throws Exception {
         QuestionBank bank = createBankWithQuestions();
-        ExamSession session = createSession("99\n", bank);
+        // Enter invalid selection, then recover with valid topic selection.
+        ExamSession session = createSession("99\n1\n\nB\nls\n", bank);
         session.startInteractive();
-        assertTrue(outStream.toString().contains("Invalid topic selection"));
+        String output = outStream.toString();
+        assertTrue(output.contains("Invalid topic selection"));
+        assertTrue(output.contains("[Q"), "Should proceed into exam after valid topic selected");
     }
 
     @Test

--- a/src/test/java/linuxlingo/exam/ExamSessionTest.java
+++ b/src/test/java/linuxlingo/exam/ExamSessionTest.java
@@ -253,6 +253,17 @@ public class ExamSessionTest {
     }
 
     @Test
+    public void runOneRandom_userQuit_printsSkipped() throws Exception {
+        QuestionBank bank = createBankWithQuestions();
+        ExamSession session = createSession("quit\n", bank);
+        session.runOneRandom();
+
+        String output = outStream.toString();
+        assertTrue(output.contains("Skipped."),
+                "Random mode should explicitly indicate a skipped question when user types quit");
+    }
+
+    @Test
     public void startInteractive_negativeCount_clampedToOne() throws Exception {
         QuestionBank bank = createBankWithQuestions();
         // Select topic 1, count "-5", then answer questions

--- a/src/test/java/linuxlingo/exam/QuestionInteractionFitbValidationTest.java
+++ b/src/test/java/linuxlingo/exam/QuestionInteractionFitbValidationTest.java
@@ -1,0 +1,71 @@
+package linuxlingo.exam;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import linuxlingo.cli.Ui;
+import linuxlingo.exam.question.FitbQuestion;
+import linuxlingo.exam.question.Question;
+
+/**
+ * Verifies that FITB empty inputs are rejected and reprompted (instead of being
+ * immediately marked incorrect).
+ */
+public class QuestionInteractionFitbValidationTest {
+
+    private static class FakeUi extends Ui {
+        private final String[] scriptedInputs;
+        private int inputIndex = 0;
+        private final StringBuilder printed = new StringBuilder();
+
+        FakeUi(String... scriptedInputs) {
+            super(new ByteArrayInputStream(new byte[0]), new PrintStream(new ByteArrayOutputStream()));
+            this.scriptedInputs = scriptedInputs;
+        }
+
+        @Override
+        public void println(String message) {
+            printed.append(message).append("\n");
+        }
+
+        @Override
+        public String readLine(String prompt) {
+            printed.append(prompt);
+            if (inputIndex >= scriptedInputs.length) {
+                return null;
+            }
+            return scriptedInputs[inputIndex++];
+        }
+
+        String getPrinted() {
+            return printed.toString();
+        }
+    }
+
+    private FitbQuestion makeQuestion() {
+        return new FitbQuestion(
+                "To print the current directory: ___",
+                "pwd prints the current working directory.",
+                Question.Difficulty.EASY,
+                List.of("pwd")
+        );
+    }
+
+    @Test
+    void presentSingleQuestion_emptyThenValid_repromptsAndAccepts() {
+        FakeUi ui = new FakeUi("", "   ", "pwd   ");
+        QuestionInteraction interaction = new QuestionInteraction(ui);
+
+        boolean correct = interaction.presentSingleQuestion(makeQuestion(), 1, 1);
+
+        assertTrue(correct);
+        assertTrue(ui.getPrinted().contains("Invalid input"));
+    }
+}
+

--- a/src/test/java/linuxlingo/exam/QuestionInteractionMcqValidationTest.java
+++ b/src/test/java/linuxlingo/exam/QuestionInteractionMcqValidationTest.java
@@ -1,0 +1,76 @@
+package linuxlingo.exam;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import linuxlingo.cli.Ui;
+import linuxlingo.exam.question.McqQuestion;
+import linuxlingo.exam.question.Question;
+
+/**
+ * Verifies that MCQ invalid inputs are rejected and reprompted (instead of being
+ * immediately marked incorrect).
+ */
+public class QuestionInteractionMcqValidationTest {
+
+    private static class FakeUi extends Ui {
+        private final String[] scriptedInputs;
+        private int inputIndex = 0;
+        private final StringBuilder printed = new StringBuilder();
+
+        FakeUi(String... scriptedInputs) {
+            super(new ByteArrayInputStream(new byte[0]), new PrintStream(new ByteArrayOutputStream()));
+            this.scriptedInputs = scriptedInputs;
+        }
+
+        @Override
+        public void println(String message) {
+            printed.append(message).append("\n");
+        }
+
+        @Override
+        public String readLine(String prompt) {
+            printed.append(prompt);
+            if (inputIndex >= scriptedInputs.length) {
+                return null;
+            }
+            return scriptedInputs[inputIndex++];
+        }
+
+        String getPrinted() {
+            return printed.toString();
+        }
+    }
+
+    private McqQuestion makeQuestion() {
+        LinkedHashMap<Character, String> options = new LinkedHashMap<>();
+        options.put('A', "cd");
+        options.put('B', "pwd");
+        options.put('C', "ls");
+        options.put('D', "dir");
+        return new McqQuestion(
+                "Which command prints the current working directory?",
+                "pwd stands for print working directory.",
+                Question.Difficulty.EASY,
+                options,
+                'B'
+        );
+    }
+
+    @Test
+    void presentSingleQuestion_invalidThenValid_repromptsAndAccepts() {
+        FakeUi ui = new FakeUi("", "pwd", "b");
+        QuestionInteraction interaction = new QuestionInteraction(ui);
+
+        boolean correct = interaction.presentSingleQuestion(makeQuestion(), 1, 1);
+        assertTrue(correct);
+        assertTrue(ui.getPrinted().contains("Invalid input"));
+    }
+}
+

--- a/src/test/java/linuxlingo/exam/question/McqQuestionTest.java
+++ b/src/test/java/linuxlingo/exam/question/McqQuestionTest.java
@@ -47,5 +47,8 @@ public class McqQuestionTest {
     void testCheckAnswerNull() {
         assertFalse(makeQuestion().checkAnswer(null));
         assertFalse(makeQuestion().checkAnswer(""));
+        assertFalse(makeQuestion().checkAnswer("pwd"));
+        assertFalse(makeQuestion().checkAnswer("B."));
+        assertFalse(makeQuestion().checkAnswer("B pwd"));
     }
 }


### PR DESCRIPTION
Added test report and fixed some bugs including:

invalid input in MCQ questions (eg. typing the answer instead of A, B, C, D or empty input)

No explanations visible for FITB and PRAC questions

Inputting invalid topic while topic selection (eg. 8 or typo in topic name)

Using quit when on exam -random simply skips the question without any indication

Bugs requiring discussion:

exam -t navigation -t file-management (duplicate topics)

starts an exam with all question from the latest topic mentioned

*expected* error message prompting user to enter command in proper format

exam command with unknown or empty flags (eg: exam -topic navigation or exam -t)

*expected* error message prompting user to enter command in proper format
*actual* exam session is started, prompting user to select topic and unknown flag is ignored




