### PR TITLE
Strengthen checking for malformed exam commands

### DIFF
--- a/src/main/java/linuxlingo/LinuxLingo.java
+++ b/src/main/java/linuxlingo/LinuxLingo.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 import linuxlingo.cli.MainParser;
 import linuxlingo.cli.Ui;
 import linuxlingo.exam.ExamSession;
+import linuxlingo.exam.ExamCommandParser;
 import linuxlingo.exam.QuestionBank;
 import linuxlingo.shell.ShellSession;
 import linuxlingo.shell.vfs.VirtualFileSystem;
@@ -146,41 +147,28 @@ public class LinuxLingo {
      * and delegating to the appropriate {@link ExamSession} method.
      */
     private static void handleExam(String[] args, ExamSession examSession) {
-        String topic = null;
-        int count = -1;
-        boolean random = false;
-        boolean listTopics = false;
-
-        for (int i = 1; i < args.length; i++) {
-            switch (args[i]) {
-            case "-t" -> {
-                if (i + 1 < args.length) {
-                    topic = args[++i];
-                }
-            }
-            case "-n" -> {
-                if (i + 1 < args.length) {
-                    try {
-                        count = Integer.parseInt(args[++i]);
-                    } catch (NumberFormatException e) {
-                        // ignore
-                    }
-                }
-            }
-            case "-random" -> random = true;
-            case "-topics" -> listTopics = true;
-            default -> { }
-            }
+        String[] examArgs = (args.length <= 1) ? new String[0] : java.util.Arrays.copyOfRange(args, 1, args.length);
+        ExamCommandParser.ParsedExamArgs parsed = ExamCommandParser.parse(examArgs);
+        if (!parsed.ok) {
+            System.out.println("Invalid exam command: " + parsed.errorMessage);
+            System.out.println(ExamCommandParser.USAGE);
+            return;
         }
 
-        if (listTopics) {
+        if (parsed.listTopics) {
             examSession.listTopics();
-        } else if (random && topic == null) {
-            examSession.runOneRandom();
-        } else if (topic != null) {
-            examSession.startWithArgs(topic, count, random);
-        } else {
-            examSession.startInteractive();
+            return;
         }
+        if (parsed.random && parsed.topic == null) {
+            examSession.runOneRandom();
+            return;
+        }
+        if (parsed.topic != null) {
+            int count = parsed.count == null ? -1 : parsed.count;
+            examSession.startWithArgs(parsed.topic, count, parsed.random);
+            return;
+        }
+
+        examSession.startInteractive();
     }
 }

--- a/src/main/java/linuxlingo/cli/MainParser.java
+++ b/src/main/java/linuxlingo/cli/MainParser.java
@@ -1,6 +1,7 @@
 package linuxlingo.cli;
 
 import linuxlingo.exam.ExamSession;
+import linuxlingo.exam.ExamCommandParser;
 import linuxlingo.shell.ShellSession;
 
 /**
@@ -145,48 +146,29 @@ public class MainParser {
      * delegating to the appropriate {@link ExamSession} method.
      */
     private void handleExam(String[] parts) {
-        if (parts.length == 1) {
-            examSession.startInteractive();
+        String[] args = (parts.length <= 1) ? new String[0] : java.util.Arrays.copyOfRange(parts, 1, parts.length);
+        ExamCommandParser.ParsedExamArgs parsed = ExamCommandParser.parse(args);
+        if (!parsed.ok) {
+            ui.println("Invalid exam command: " + parsed.errorMessage);
+            ui.println(ExamCommandParser.USAGE);
             return;
         }
 
-        String topic = null;
-        int count = -1;
-        boolean random = false;
-        boolean listTopics = false;
-
-        for (int i = 1; i < parts.length; i++) {
-            switch (parts[i]) {
-            case "-t" -> {
-                if (i + 1 < parts.length) {
-                    topic = parts[++i];
-                }
-            }
-            case "-n" -> {
-                if (i + 1 < parts.length) {
-                    try {
-                        count = Integer.parseInt(parts[++i]);
-                    } catch (NumberFormatException e) {
-                        ui.println("Invalid count: " + parts[i]);
-                        return;
-                    }
-                }
-            }
-            case "-random" -> random = true;
-            case "-topics" -> listTopics = true;
-            default -> { }
-            }
-        }
-
-        if (listTopics) {
+        if (parsed.listTopics) {
             examSession.listTopics();
-        } else if (random && topic == null) {
-            examSession.runOneRandom();
-        } else if (topic != null) {
-            examSession.startWithArgs(topic, count, random);
-        } else {
-            examSession.startInteractive();
+            return;
         }
+        if (parsed.random && parsed.topic == null) {
+            examSession.runOneRandom();
+            return;
+        }
+        if (parsed.topic != null) {
+            int count = parsed.count == null ? -1 : parsed.count;
+            examSession.startWithArgs(parsed.topic, count, parsed.random);
+            return;
+        }
+
+        examSession.startInteractive();
     }
 
     /** Prints the list of available top-level commands to the UI. */

--- a/src/main/java/linuxlingo/exam/ExamCommandParser.java
+++ b/src/main/java/linuxlingo/exam/ExamCommandParser.java
@@ -17,133 +17,136 @@ import java.util.Set;
  * <p>This parser rejects unknown flags, duplicate flags, and missing required values.
  */
 public final class ExamCommandParser {
-	private ExamCommandParser() {
-		// utility
-	}
 
-	/** Usage string shown on parsing errors. */
-	public static final String USAGE = String.join(System.lineSeparator(),
-			"Usage:",
-			"  exam                         Start an exam (interactive topic selection)",
-			"  exam -t TOPIC [-n COUNT] [-random]",
-			"  exam -topics                 List all available exam topics",
-			"  exam -random                 One random question, then return");
+    /** Usage string shown on parsing errors. */
+    public static final String USAGE = String.join(System.lineSeparator(),
+            "Usage:",
+            "  exam                         Start an exam (interactive topic selection)",
+            "  exam -t TOPIC [-n COUNT] [-random]",
+            "  exam -topics                 List all available exam topics",
+            "  exam -random                 One random question, then return");
 
-	/** Parsed result for an exam command, or an error with a message+usage. */
-	public static final class ParsedExamArgs {
-		public final String topic;
-		public final Integer count;
-		public final boolean random;
-		public final boolean listTopics;
+    private ExamCommandParser() {
+        // utility
+    }
 
-		public final boolean ok;
-		public final String errorMessage;
 
-		private ParsedExamArgs(String topic, Integer count, boolean random, boolean listTopics,
-							   boolean ok, String errorMessage) {
-			this.topic = topic;
-			this.count = count;
-			this.random = random;
-			this.listTopics = listTopics;
-			this.ok = ok;
-			this.errorMessage = errorMessage;
-		}
+    /** Parsed result for an exam command, or an error with a message+usage. */
+    public static final class ParsedExamArgs {
+        public final String topic;
+        public final Integer count;
+        public final boolean random;
+        public final boolean listTopics;
 
-		public static ParsedExamArgs success(String topic, Integer count, boolean random, boolean listTopics) {
-			return new ParsedExamArgs(topic, count, random, listTopics, true, null);
-		}
+        public final boolean ok;
+        public final String errorMessage;
 
-		public static ParsedExamArgs error(String message) {
-			return new ParsedExamArgs(null, null, false, false, false, message);
-		}
-	}
+        private ParsedExamArgs(String topic, Integer count, boolean random, boolean listTopics,
+                               boolean ok, String errorMessage) {
+            this.topic = topic;
+            this.count = count;
+            this.random = random;
+            this.listTopics = listTopics;
+            this.ok = ok;
+            this.errorMessage = errorMessage;
+        }
 
-	/**
-	 * Parse tokens that come after the {@code exam} command.
-	 *
-	 * @param args tokens after {@code exam} (may be empty)
-	 */
-	public static ParsedExamArgs parse(String[] args) {
-		String topic = null;
-		Integer count = null;
-		boolean random = false;
-		boolean listTopics = false;
+        public static ParsedExamArgs success(String topic, Integer count, boolean random, boolean listTopics) {
+            return new ParsedExamArgs(topic, count, random, listTopics, true, null);
+        }
 
-		Set<String> seen = new HashSet<>();
+        public static ParsedExamArgs error(String message) {
+            return new ParsedExamArgs(null, null, false, false, false, message);
+        }
+    }
 
-		for (int i = 0; i < args.length; i++) {
-			String token = args[i];
-			switch (token) {
-			case "-t" -> {
-				if (!seen.add("-t")) {
-					return ParsedExamArgs.error("Duplicate flag: -t");
-				}
-				String value = requireValue(args, i);
-				if (value == null) {
-					return ParsedExamArgs.error("Missing value for -t");
-				}
-				topic = value;
-				i++; // consume value
-			}
-			case "-n" -> {
-				if (!seen.add("-n")) {
-					return ParsedExamArgs.error("Duplicate flag: -n");
-				}
-				String value = requireValue(args, i);
-				if (value == null) {
-					return ParsedExamArgs.error("Missing value for -n");
-				}
-				try {
-					count = Integer.parseInt(value);
-				} catch (NumberFormatException e) {
-					return ParsedExamArgs.error("Invalid count: " + value);
-				}
-				i++; // consume value
-			}
-			case "-random" -> {
-				if (!seen.add("-random")) {
-					return ParsedExamArgs.error("Duplicate flag: -random");
-				}
-				random = true;
-			}
-			case "-topics" -> {
-				if (!seen.add("-topics")) {
-					return ParsedExamArgs.error("Duplicate flag: -topics");
-				}
-				listTopics = true;
-			}
-			default -> {
-				if (token.startsWith("-")) {
-					return ParsedExamArgs.error("Unknown flag: " + token);
-				}
-				return ParsedExamArgs.error("Unexpected argument: " + token);
-			}
-			}
-		}
 
-		if (listTopics && (topic != null || count != null || random)) {
-			return ParsedExamArgs.error("-topics cannot be combined with other flags");
-		}
+    /**
+     * Parse tokens that come after the {@code exam} command.
+     *
+     * @param args tokens after {@code exam} (may be empty)
+     */
+    public static ParsedExamArgs parse(String[] args) {
+        String topic = null;
+        Integer count = null;
+        boolean random = false;
+        boolean listTopics = false;
 
-		// Spec: exam -t TOPIC [-n COUNT] [-random]
-		// If -n is provided, topic is required (otherwise behaviour is ambiguous).
-		if (count != null && topic == null) {
-			return ParsedExamArgs.error("-n requires -t TOPIC");
-		}
+        Set<String> seen = new HashSet<>();
 
-		return ParsedExamArgs.success(topic, count, random, listTopics);
-	}
+        for (int i = 0; i < args.length; i++) {
+            String token = args[i];
+            switch (token) {
+            case "-t" -> {
+                if (!seen.add("-t")) {
+                    return ParsedExamArgs.error("Duplicate flag: -t");
+                }
+                String value = requireValue(args, i);
+                if (value == null) {
+                    return ParsedExamArgs.error("Missing value for -t");
+                }
+                topic = value;
+                i++; // consume value
+            }
+            case "-n" -> {
+                if (!seen.add("-n")) {
+                    return ParsedExamArgs.error("Duplicate flag: -n");
+                }
+                String value = requireValue(args, i);
+                if (value == null) {
+                    return ParsedExamArgs.error("Missing value for -n");
+                }
+                try {
+                    count = Integer.parseInt(value);
+                } catch (NumberFormatException e) {
+                    return ParsedExamArgs.error("Invalid count: " + value);
+                }
+                i++; // consume value
+            }
+            case "-random" -> {
+                if (!seen.add("-random")) {
+                    return ParsedExamArgs.error("Duplicate flag: -random");
+                }
+                random = true;
+            }
+            case "-topics" -> {
+                if (!seen.add("-topics")) {
+                    return ParsedExamArgs.error("Duplicate flag: -topics");
+                }
+                listTopics = true;
+            }
+            default -> {
+                if (token.startsWith("-")) {
+                    return ParsedExamArgs.error("Unknown flag: " + token);
+                }
+                return ParsedExamArgs.error("Unexpected argument: " + token);
+            }
+            }
+        }
 
-	private static String requireValue(String[] args, int flagIndex) {
-		int valueIndex = flagIndex + 1;
-		if (valueIndex >= args.length) {
-			return null;
-		}
-		String value = args[valueIndex];
-		if (value.startsWith("-")) {
-			return null;
-		}
-		return value;
-	}
+        if (listTopics && (topic != null || count != null || random)) {
+            return ParsedExamArgs.error("-topics cannot be combined with other flags");
+        }
+
+        // Spec: exam -t TOPIC [-n COUNT] [-random]
+        // If -n is provided, topic is required (otherwise behaviour is ambiguous).
+        if (count != null && topic == null) {
+            return ParsedExamArgs.error("-n requires -t TOPIC");
+        }
+
+        return ParsedExamArgs.success(topic, count, random, listTopics);
+    }
+
+    private static String requireValue(String[] args, int flagIndex) {
+        int valueIndex = flagIndex + 1;
+        if (valueIndex >= args.length) {
+            return null;
+        }
+        String value = args[valueIndex];
+        if (value.startsWith("-")) {
+            return null;
+        }
+        return value;
+    }
 }
 

--- a/src/main/java/linuxlingo/exam/ExamCommandParser.java
+++ b/src/main/java/linuxlingo/exam/ExamCommandParser.java
@@ -1,0 +1,149 @@
+package linuxlingo.exam;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Strict parser for {@code exam} command flags.
+ *
+ * <p>Supported formats:
+ * <ul>
+ *   <li>{@code exam} (interactive)</li>
+ *   <li>{@code exam -t TOPIC [-n COUNT] [-random]}</li>
+ *   <li>{@code exam -topics}</li>
+ *   <li>{@code exam -random} (one random question)</li>
+ * </ul>
+ *
+ * <p>This parser rejects unknown flags, duplicate flags, and missing required values.
+ */
+public final class ExamCommandParser {
+	private ExamCommandParser() {
+		// utility
+	}
+
+	/** Usage string shown on parsing errors. */
+	public static final String USAGE = String.join(System.lineSeparator(),
+			"Usage:",
+			"  exam                         Start an exam (interactive topic selection)",
+			"  exam -t TOPIC [-n COUNT] [-random]",
+			"  exam -topics                 List all available exam topics",
+			"  exam -random                 One random question, then return");
+
+	/** Parsed result for an exam command, or an error with a message+usage. */
+	public static final class ParsedExamArgs {
+		public final String topic;
+		public final Integer count;
+		public final boolean random;
+		public final boolean listTopics;
+
+		public final boolean ok;
+		public final String errorMessage;
+
+		private ParsedExamArgs(String topic, Integer count, boolean random, boolean listTopics,
+							   boolean ok, String errorMessage) {
+			this.topic = topic;
+			this.count = count;
+			this.random = random;
+			this.listTopics = listTopics;
+			this.ok = ok;
+			this.errorMessage = errorMessage;
+		}
+
+		public static ParsedExamArgs success(String topic, Integer count, boolean random, boolean listTopics) {
+			return new ParsedExamArgs(topic, count, random, listTopics, true, null);
+		}
+
+		public static ParsedExamArgs error(String message) {
+			return new ParsedExamArgs(null, null, false, false, false, message);
+		}
+	}
+
+	/**
+	 * Parse tokens that come after the {@code exam} command.
+	 *
+	 * @param args tokens after {@code exam} (may be empty)
+	 */
+	public static ParsedExamArgs parse(String[] args) {
+		String topic = null;
+		Integer count = null;
+		boolean random = false;
+		boolean listTopics = false;
+
+		Set<String> seen = new HashSet<>();
+
+		for (int i = 0; i < args.length; i++) {
+			String token = args[i];
+			switch (token) {
+			case "-t" -> {
+				if (!seen.add("-t")) {
+					return ParsedExamArgs.error("Duplicate flag: -t");
+				}
+				String value = requireValue(args, i);
+				if (value == null) {
+					return ParsedExamArgs.error("Missing value for -t");
+				}
+				topic = value;
+				i++; // consume value
+			}
+			case "-n" -> {
+				if (!seen.add("-n")) {
+					return ParsedExamArgs.error("Duplicate flag: -n");
+				}
+				String value = requireValue(args, i);
+				if (value == null) {
+					return ParsedExamArgs.error("Missing value for -n");
+				}
+				try {
+					count = Integer.parseInt(value);
+				} catch (NumberFormatException e) {
+					return ParsedExamArgs.error("Invalid count: " + value);
+				}
+				i++; // consume value
+			}
+			case "-random" -> {
+				if (!seen.add("-random")) {
+					return ParsedExamArgs.error("Duplicate flag: -random");
+				}
+				random = true;
+			}
+			case "-topics" -> {
+				if (!seen.add("-topics")) {
+					return ParsedExamArgs.error("Duplicate flag: -topics");
+				}
+				listTopics = true;
+			}
+			default -> {
+				if (token.startsWith("-")) {
+					return ParsedExamArgs.error("Unknown flag: " + token);
+				}
+				return ParsedExamArgs.error("Unexpected argument: " + token);
+			}
+			}
+		}
+
+		if (listTopics && (topic != null || count != null || random)) {
+			return ParsedExamArgs.error("-topics cannot be combined with other flags");
+		}
+
+		// Spec: exam -t TOPIC [-n COUNT] [-random]
+		// If -n is provided, topic is required (otherwise behaviour is ambiguous).
+		if (count != null && topic == null) {
+			return ParsedExamArgs.error("-n requires -t TOPIC");
+		}
+
+		return ParsedExamArgs.success(topic, count, random, listTopics);
+	}
+
+	private static String requireValue(String[] args, int flagIndex) {
+		int valueIndex = flagIndex + 1;
+		if (valueIndex >= args.length) {
+			return null;
+		}
+		String value = args[valueIndex];
+		if (value.startsWith("-")) {
+			return null;
+		}
+		return value;
+	}
+}
+

--- a/src/main/java/linuxlingo/exam/ExamCommandParser.java
+++ b/src/main/java/linuxlingo/exam/ExamCommandParser.java
@@ -75,7 +75,8 @@ public final class ExamCommandParser {
         Set<String> seen = new HashSet<>();
 
         for (int i = 0; i < args.length; i++) {
-            String token = args[i];
+            // Be defensive: callers may pass tokens with extra whitespace.
+            String token = args[i] == null ? "" : args[i].trim();
             switch (token) {
             case "-t" -> {
                 if (!seen.add("-t")) {
@@ -97,7 +98,7 @@ public final class ExamCommandParser {
                     return ParsedExamArgs.error("Missing value for -n");
                 }
                 try {
-                    count = Integer.parseInt(value);
+                    count = Integer.parseInt(value.trim());
                 } catch (NumberFormatException e) {
                     return ParsedExamArgs.error("Invalid count: " + value);
                 }
@@ -143,7 +144,11 @@ public final class ExamCommandParser {
             return null;
         }
         String value = args[valueIndex];
-        if (value.startsWith("-")) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        if (value.isEmpty() || value.startsWith("-")) {
             return null;
         }
         return value;

--- a/src/main/java/linuxlingo/exam/QuestionInteraction.java
+++ b/src/main/java/linuxlingo/exam/QuestionInteraction.java
@@ -111,15 +111,7 @@ class QuestionInteraction {
         Objects.requireNonNull(question, "question must not be null");
         Objects.requireNonNull(result, "result must not be null");
 
-        String userAnswer;
-        if (question instanceof McqQuestion) {
-            userAnswer = askValidatedMcqAnswer((McqQuestion) question, index, total);
-        } else if (question instanceof FitbQuestion) {
-            userAnswer = askValidatedFitbAnswer((FitbQuestion) question, index, total);
-        } else {
-            userAnswer = askQuestion(question, index, total);
-        }
-
+        String userAnswer = askQuestion(question, index, total);
         if (userAnswer != null && userAnswer.trim().equalsIgnoreCase("abort")) {
             examAborted = true;
             ui.println("Exam aborted.");

--- a/src/test/java/linuxlingo/LinuxLingoTest.java
+++ b/src/test/java/linuxlingo/LinuxLingoTest.java
@@ -133,8 +133,9 @@ public class LinuxLingoTest {
     @Test
     void oneShot_examInvalidCountDoesNotCrash() {
         LinuxLingo.main(new String[]{"exam", "-n", "notanumber"});
-        // Should swallow the NumberFormatException and fall back to startInteractive
-        assertTrue(true);
+        String out = outBytes.toString();
+        assertTrue(out.contains("Invalid exam command") && out.contains("Usage"),
+                "Invalid -n value should show usage error, got: " + out);
     }
 
     @Test
@@ -146,8 +147,41 @@ public class LinuxLingoTest {
     @Test
     void oneShot_examUnknownArgsFallsBackToInteractive() {
         LinuxLingo.main(new String[]{"exam", "-unknown"});
-        // Unknown flag is silently skipped; falls back to startInteractive
-        assertTrue(true);
+        String out = outBytes.toString();
+        assertTrue(out.contains("Invalid exam command") && out.contains("Usage"),
+                "Unknown exam flag should show usage error, got: " + out);
+    }
+
+    @Test
+    void oneShot_examDuplicateTopicFlagPrintsUsageError() {
+        LinuxLingo.main(new String[]{"exam", "-t", "navigation", "-t", "file-management"});
+        String out = outBytes.toString();
+        assertTrue(out.contains("Duplicate flag") && out.contains("Usage"),
+                "Duplicate -t should be rejected, got: " + out);
+    }
+
+    @Test
+    void oneShot_examMissingTopicValuePrintsUsageError() {
+        LinuxLingo.main(new String[]{"exam", "-t"});
+        String out = outBytes.toString();
+        assertTrue(out.contains("Missing value") && out.contains("Usage"),
+                "Missing -t value should be rejected, got: " + out);
+    }
+
+    @Test
+    void oneShot_examCountWithoutTopicPrintsUsageError() {
+        LinuxLingo.main(new String[]{"exam", "-n", "5"});
+        String out = outBytes.toString();
+        assertTrue(out.contains("requires -t") && out.contains("Usage"),
+                "-n without -t should be rejected, got: " + out);
+    }
+
+    @Test
+    void oneShot_examCountAndRandomWithoutTopicPrintsUsageError() {
+        LinuxLingo.main(new String[]{"exam", "-n", "3", "-random"});
+        String out = outBytes.toString();
+        assertTrue(out.contains("requires -t") && out.contains("Usage"),
+                "-n with -random but without -t should be rejected, got: " + out);
     }
 
     // ─── shell one-shot mode ──────────────────────────────────────

--- a/src/test/java/linuxlingo/cli/MainParserTest.java
+++ b/src/test/java/linuxlingo/cli/MainParserTest.java
@@ -215,7 +215,54 @@ public class MainParserTest {
     public void run_examUnknownFlag_fallsBackGracefully() {
         MainParser parser = createParser("exam -unknown\nexit\n");
         parser.run();
-        assertTrue(outStream.toString().contains("Goodbye!"));
+        String output = outStream.toString();
+        assertTrue(output.contains("Invalid exam command") && output.contains("Usage"),
+                "Unknown exam flag should show usage error, got: " + output);
+    }
+
+    @Test
+    public void run_examDuplicateTopicFlag_showsUsageError() {
+        MainParser parser = createParser("exam -t navigation -t file-management\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("Duplicate flag") && output.contains("Usage"),
+                "Duplicate -t should be rejected, got: " + output);
+    }
+
+    @Test
+    public void run_examMissingTopicValue_showsUsageError() {
+        MainParser parser = createParser("exam -t\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("Missing value") && output.contains("Usage"),
+                "Missing -t value should be rejected, got: " + output);
+    }
+
+    @Test
+    public void run_examMissingCountValue_showsUsageError() {
+        MainParser parser = createParser("exam -n\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("Missing value") && output.contains("Usage"),
+                "Missing -n value should be rejected, got: " + output);
+    }
+
+    @Test
+    public void run_examCountWithoutTopic_showsUsageError() {
+        MainParser parser = createParser("exam -n 5\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("requires -t") && output.contains("Usage"),
+                "-n without -t should be rejected, got: " + output);
+    }
+
+    @Test
+    public void run_examCountAndRandomWithoutTopic_showsUsageError() {
+        MainParser parser = createParser("exam -n 3 -random\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("requires -t") && output.contains("Usage"),
+                "-n with -random but without -t should be rejected, got: " + output);
     }
 
     // ─── case sensitivity of command dispatch ─────────────────────


### PR DESCRIPTION
closes #210 

Made exam command parsing stricter, restricting malformed commands with incorrect or duplicate flags and missing parameters