### PR TITLE
Commands with multiple invalid paths report only the first missing operand

### DIFF
--- a/src/main/java/linuxlingo/shell/command/CatCommand.java
+++ b/src/main/java/linuxlingo/shell/command/CatCommand.java
@@ -50,7 +50,7 @@ public class CatCommand implements Command {
                     hasError = true;
                 }
             }
-            String result = sb.toString().trim();
+            String result = sb.toString();
 
             return hasError ? CommandResult.error(result) : CommandResult.success(result);
         }

--- a/src/main/java/linuxlingo/shell/command/CatCommand.java
+++ b/src/main/java/linuxlingo/shell/command/CatCommand.java
@@ -35,6 +35,7 @@ public class CatCommand implements Command {
 
         StringBuilder sb = new StringBuilder();
         int lineNumber = 1;
+        boolean hasError = false;
 
         if (!files.isEmpty()) {
             for (String file : files) {
@@ -42,10 +43,16 @@ public class CatCommand implements Command {
                     String content = session.getVfs().readFile(file, session.getWorkingDir());
                     lineNumber = appendContent(sb, content, numberLines, lineNumber);
                 } catch (VfsException e) {
-                    return CommandResult.error("cat: " + e.getMessage());
+                    if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != '\n') {
+                        sb.append("\n");
+                    }
+                    sb.append("cat: ").append(e.getMessage()).append("\n");
+                    hasError = true;
                 }
             }
-            return CommandResult.success(sb.toString());
+            String result = sb.toString().trim();
+
+            return hasError ? CommandResult.error(result) : CommandResult.success(result);
         }
 
         if (stdin != null) {
@@ -59,7 +66,7 @@ public class CatCommand implements Command {
 
         return CommandResult.error(
                 "cat: reading from stdin is not supported in LinuxLingo."
-                + " Provide a filename or use piping.");
+                        + " Provide a filename or use piping.");
     }
 
     private int appendContent(StringBuilder sb, String content, boolean numberLines, int lineNumber) {

--- a/src/main/java/linuxlingo/shell/command/CpCommand.java
+++ b/src/main/java/linuxlingo/shell/command/CpCommand.java
@@ -41,18 +41,27 @@ public class CpCommand implements Command {
                     || !session.getVfs().resolve(dest, session.getWorkingDir()).isDirectory()) {
                 return CommandResult.error("cp: target '" + dest + "' is not a directory");
             }
+
+            StringBuilder sb = new StringBuilder();
+            boolean hasError = false;
+
             for (int i = 0; i < paths.size() - 1; i++) {
                 try {
                     CommandResult validationError = validateCopy(session, paths.get(i), dest);
                     if (validationError != null) {
-                        return validationError;
+                        sb.append(validationError.getStderr()).append("\n");
+                        hasError = true;
+                        continue;
                     }
+
                     session.getVfs().copy(paths.get(i), dest, session.getWorkingDir(), recursive);
                 } catch (VfsException e) {
-                    return CommandResult.error("cp: " + e.getMessage());
+                    sb.append("cp: ").append(e.getMessage()).append("\n");
+                    hasError = true;
                 }
             }
-            return CommandResult.success("");
+            String result = sb.toString().trim();
+            return hasError ? CommandResult.error(result) : CommandResult.success("");
         }
 
         try {

--- a/src/main/java/linuxlingo/shell/command/DiffCommand.java
+++ b/src/main/java/linuxlingo/shell/command/DiffCommand.java
@@ -24,17 +24,25 @@ public class DiffCommand implements Command {
         String file1Path = args[0];
         String file2Path = args[1];
 
-        String content1;
-        String content2;
+        String content1 = null;
+        String content2 = null;
+
+        List<String> errors = new ArrayList<>();
+
         try {
             content1 = session.getVfs().readFile(file1Path, session.getWorkingDir());
         } catch (VfsException e) {
-            return CommandResult.error("diff: " + e.getMessage());
+            errors.add("diff: " + e.getMessage());
         }
+
         try {
             content2 = session.getVfs().readFile(file2Path, session.getWorkingDir());
         } catch (VfsException e) {
-            return CommandResult.error("diff: " + e.getMessage());
+            errors.add("diff: " + e.getMessage());
+        }
+
+        if (!errors.isEmpty()) {
+            return CommandResult.error(String.join("\n", errors));
         }
 
         if (content1.equals(content2)) {

--- a/src/main/java/linuxlingo/shell/command/HeadCommand.java
+++ b/src/main/java/linuxlingo/shell/command/HeadCommand.java
@@ -54,6 +54,8 @@ public class HeadCommand implements Command {
         }
 
         List<String> output = new ArrayList<>();
+        boolean hasError = false;
+
         boolean multiFile = files.size() > 1;
 
         if (!files.isEmpty()) {
@@ -68,14 +70,16 @@ public class HeadCommand implements Command {
                     }
                     appendHeadLines(output, content, n);
                 } catch (VfsException e) {
-                    return CommandResult.error("head: " + e.getMessage());
+                    output.add("head: " + files.get(i) + ": " + e.getMessage());
+                    hasError = true;
                 }
             }
         } else {
             appendHeadLines(output, stdin, n);
         }
 
-        return CommandResult.success(String.join("\n", output));
+        String result = String.join("\n", output);
+        return hasError ? CommandResult.error(result) : CommandResult.success(result);
     }
 
     private void appendHeadLines(List<String> output, String content, int n) {

--- a/src/main/java/linuxlingo/shell/command/LsCommand.java
+++ b/src/main/java/linuxlingo/shell/command/LsCommand.java
@@ -56,13 +56,14 @@ public class LsCommand implements Command {
             targetPaths.add(session.getWorkingDir());
         }
 
-        try {
-            List<String> lines = new ArrayList<>();
-            boolean multiTarget = targetPaths.size() > 1;
+        List<String> lines = new ArrayList<>();
+        boolean hasError = false;
+        boolean multiTarget = targetPaths.size() > 1;
 
-            for (int t = 0; t < targetPaths.size(); t++) {
-                String targetPath = targetPaths.get(t);
+        for (int t = 0; t < targetPaths.size(); t++) {
+            String targetPath = targetPaths.get(t);
 
+            try {
                 // Check if the target is a file (not a directory) — display it directly (#143)
                 FileNode targetNode = session.getVfs().resolve(targetPath, session.getWorkingDir());
                 if (!targetNode.isDirectory()) {
@@ -87,11 +88,15 @@ public class LsCommand implements Command {
                 } else {
                     listDirectory(session, targetPath, longFormat, showHidden, lines);
                 }
+            } catch (VfsException e) {
+                lines.add("ls: " + e.getMessage());
+                hasError = true;
             }
-            return CommandResult.success(String.join("\n", lines));
-        } catch (VfsException e) {
-            return CommandResult.error("ls: " + e.getMessage());
         }
+
+        String result = String.join("\n", lines);
+
+        return hasError ? CommandResult.error(result) : CommandResult.success(result);
     }
 
     /**

--- a/src/main/java/linuxlingo/shell/command/MvCommand.java
+++ b/src/main/java/linuxlingo/shell/command/MvCommand.java
@@ -34,14 +34,21 @@ public class MvCommand implements Command {
                     || !session.getVfs().resolve(dest, session.getWorkingDir()).isDirectory()) {
                 return CommandResult.error("mv: target '" + dest + "' is not a directory");
             }
+
+            StringBuilder sb = new StringBuilder();
+            boolean hasError = false;
+
             for (int i = 0; i < paths.size() - 1; i++) {
                 try {
                     session.getVfs().move(paths.get(i), dest, session.getWorkingDir());
                 } catch (VfsException e) {
-                    return CommandResult.error("mv: " + e.getMessage());
+                    sb.append("mv: ").append(e.getMessage()).append("\n");
+                    hasError = true;
                 }
             }
-            return CommandResult.success("");
+
+            String result = sb.toString().trim();
+            return hasError ? CommandResult.error(result) : CommandResult.success("");
         }
 
         try {

--- a/src/main/java/linuxlingo/shell/command/RmCommand.java
+++ b/src/main/java/linuxlingo/shell/command/RmCommand.java
@@ -37,21 +37,27 @@ public class RmCommand implements Command {
             return CommandResult.error("rm: missing operand");
         }
 
+        StringBuilder sb = new StringBuilder();
+        boolean hasError = false;
+
         for (String path : paths) {
             try {
                 String absTarget = session.getVfs().getAbsolutePath(path, session.getWorkingDir());
                 String absCwd = session.getVfs().getAbsolutePath(session.getWorkingDir(), "/");
                 if (absCwd.equals(absTarget) || absCwd.startsWith(absTarget + "/")) {
-                    return CommandResult.error("rm: cannot remove '" + path
-                            + "': current working directory is inside this directory");
+                    sb.append("rm: cannot remove'").append(path).append("': current working directory is inside this directory").append("\n");
+                    hasError = true;
+                    continue;
                 }
                 session.getVfs().delete(path, session.getWorkingDir(), recursive, force);
             } catch (VfsException e) {
-                return CommandResult.error("rm: " + e.getMessage());
+                sb.append("rm: ").append(e.getMessage()).append("\n");
+                hasError = true;
             }
         }
 
-        return CommandResult.success("");
+        String result = sb.toString().trim();
+        return hasError ? CommandResult.error(result) : CommandResult.success("");
     }
 
     @Override

--- a/src/main/java/linuxlingo/shell/command/RmCommand.java
+++ b/src/main/java/linuxlingo/shell/command/RmCommand.java
@@ -45,7 +45,10 @@ public class RmCommand implements Command {
                 String absTarget = session.getVfs().getAbsolutePath(path, session.getWorkingDir());
                 String absCwd = session.getVfs().getAbsolutePath(session.getWorkingDir(), "/");
                 if (absCwd.equals(absTarget) || absCwd.startsWith(absTarget + "/")) {
-                    sb.append("rm: cannot remove'").append(path).append("': current working directory is inside this directory").append("\n");
+                    sb.append("rm: cannot remove'")
+                            .append(path)
+                            .append("': current working directory is inside this directory")
+                            .append("\n");
                     hasError = true;
                     continue;
                 }

--- a/src/main/java/linuxlingo/shell/command/TailCommand.java
+++ b/src/main/java/linuxlingo/shell/command/TailCommand.java
@@ -72,6 +72,8 @@ public class TailCommand implements Command {
         }
 
         List<String> output = new ArrayList<>();
+        boolean hasError = false;
+
         boolean multiFile = files.size() > 1;
 
         if (!files.isEmpty()) {
@@ -90,7 +92,8 @@ public class TailCommand implements Command {
                         appendTailLines(output, content, n);
                     }
                 } catch (VfsException e) {
-                    return CommandResult.error("tail: " + e.getMessage());
+                    output.add("tail: " + files.get(i) + ": " + e.getMessage());
+                    hasError = true;
                 }
             }
         } else {
@@ -101,7 +104,8 @@ public class TailCommand implements Command {
             }
         }
 
-        return CommandResult.success(String.join("\n", output));
+        String result = String.join("\n", output);
+        return hasError ? CommandResult.error(result) : CommandResult.success(result);
     }
 
     private void appendTailLines(List<String> output, String content, int n) {


### PR DESCRIPTION
Closes #208 

Fix the following commands to properly handle multi file paths. Before, the command immediately returns when an error occurs, even if there are other valid paths in the command. Now, the command only returns after each path has been processed.

`cat, cp, diff, head, tail, rm, mv, ls`

