### PR TITLE
Validate top-level shell and exec arguments

### DIFF
--- a/src/main/java/linuxlingo/LinuxLingo.java
+++ b/src/main/java/linuxlingo/LinuxLingo.java
@@ -6,8 +6,8 @@ import java.util.logging.Logger;
 
 import linuxlingo.cli.MainParser;
 import linuxlingo.cli.Ui;
-import linuxlingo.exam.ExamSession;
 import linuxlingo.exam.ExamCommandParser;
+import linuxlingo.exam.ExamSession;
 import linuxlingo.exam.QuestionBank;
 import linuxlingo.shell.ShellSession;
 import linuxlingo.shell.vfs.VirtualFileSystem;
@@ -85,7 +85,14 @@ public class LinuxLingo {
     private static void handleOneShot(String[] args, Ui ui,
                                       ShellSession shellSession, ExamSession examSession) {
         switch (args[0]) {
-        case "shell" -> shellSession.startInteractive();
+        case "shell" -> {
+            if (args.length > 1) {
+                ui.println("shell: too many arguments");
+                ui.println("Usage: java -jar LinuxLingo.jar shell");
+                return;
+            }
+            shellSession.startInteractive();
+        }
         case "exec" -> handleExec(args, ui, shellSession);
         case "exam" -> handleExam(args, examSession);
         default -> {
@@ -164,7 +171,8 @@ public class LinuxLingo {
             return;
         }
         if (parsed.topic != null) {
-            int count = parsed.count == null ? -1 : parsed.count;
+            Integer parsedCount = parsed.count;
+            int count = parsedCount == null ? -1 : parsedCount;
             examSession.startWithArgs(parsed.topic, count, parsed.random);
             return;
         }

--- a/src/main/java/linuxlingo/cli/MainParser.java
+++ b/src/main/java/linuxlingo/cli/MainParser.java
@@ -1,7 +1,7 @@
 package linuxlingo.cli;
 
-import linuxlingo.exam.ExamSession;
 import linuxlingo.exam.ExamCommandParser;
+import linuxlingo.exam.ExamSession;
 import linuxlingo.shell.ShellSession;
 
 /**
@@ -67,6 +67,11 @@ public class MainParser {
 
         switch (command) {
         case "shell" -> {
+            if (parts.length > 1) {
+                ui.println("shell: too many arguments");
+                ui.println("Usage: shell");
+                return true;
+            }
             shellSession.startInteractive();
             return true;
         }
@@ -99,15 +104,23 @@ public class MainParser {
     private void handleExec(String input) {
         // Extract the command string after "exec"
         String rest = input.substring(4).trim();
-        // Remove optional -e flag
         String envName = null;
-        if (rest.startsWith("-e ")) {
-            String[] execParts = rest.split("\\s+", 3);
-            if (execParts.length >= 3) {
-                envName = execParts[1];
-                rest = execParts[2];
+        String[] execParts = rest.isEmpty() ? new String[0] : rest.split("\\s+", 3);
+        if (execParts.length > 0 && "-e".equals(execParts[0])) {
+            if (execParts.length < 2 || execParts[1].isBlank()) {
+                ui.println("exec -e: missing environment name");
+                ui.println("Usage: exec -e <env> \"<command>\"");
+                return;
             }
+            if (execParts.length < 3 || execParts[2].isBlank()) {
+                ui.println("exec -e: missing command after environment name");
+                ui.println("Usage: exec -e <env> \"<command>\"");
+                return;
+            }
+            envName = execParts[1];
+            rest = execParts[2];
         }
+
         // Remove surrounding quotes if present
         if ((rest.startsWith("\"") && rest.endsWith("\""))
                 || (rest.startsWith("'") && rest.endsWith("'"))) {
@@ -163,7 +176,8 @@ public class MainParser {
             return;
         }
         if (parsed.topic != null) {
-            int count = parsed.count == null ? -1 : parsed.count;
+            Integer parsedCount = parsed.count;
+            int count = parsedCount == null ? -1 : parsedCount;
             examSession.startWithArgs(parsed.topic, count, parsed.random);
             return;
         }

--- a/src/test/java/linuxlingo/LinuxLingoTest.java
+++ b/src/test/java/linuxlingo/LinuxLingoTest.java
@@ -53,8 +53,10 @@ public class LinuxLingoTest {
     void oneShot_unknownCommand_printsUsage() {
         LinuxLingo.main(new String[]{"unknowncmd"});
         String out = outBytes.toString();
-        assertTrue(out.contains("Unknown command") || out.contains("Usage"),
-                "Should print Unknown command or Usage hint, got: " + out);
+        assertTrue(out.contains("Unknown command: unknowncmd"),
+            "Should identify the unknown command, got: " + out);
+        assertTrue(out.contains("Usage: java -jar LinuxLingo.jar [shell|exec|exam]"),
+            "Should print one-shot usage guidance, got: " + out);
     }
 
     // ─── exec one-shot mode ───────────────────────────────────────
@@ -76,12 +78,12 @@ public class LinuxLingoTest {
 
     @Test
     void oneShot_execMissingEnvNamePrintsMissingCommand() {
-        // -e without enough args falls through to the normal path (cmdStart=1, args[1]="-e")
-        // With only 2 args: exec -e  → cmdStart stays at 1, command becomes "-e"
         LinuxLingo.main(new String[]{"exec", "-e"});
-        // Should not crash; output may contain error or missing command —
-        // as long as the JVM does not throw an uncaught exception, this is acceptable.
-        assertTrue(true, "main() should not throw for exec -e with missing args");
+        String out = outBytes.toString();
+        assertTrue(out.contains("exec -e: missing command after environment name"),
+            "Missing env command should be reported, got: " + out);
+        assertTrue(out.contains("Usage: java -jar LinuxLingo.jar exec -e <env> <command>"),
+            "Should print exec -e usage guidance, got: " + out);
     }
 
     @Test
@@ -106,82 +108,47 @@ public class LinuxLingoTest {
     @Test
     void oneShot_examTopicsFlagListsTopicsOrEmpty() {
         LinuxLingo.main(new String[]{"exam", "-topics"});
-        // Should not throw; may output "No topics" or topic list
-        assertTrue(true);
-    }
-
-    @Test
-    void oneShot_examRandomFlagDoesNotCrash() {
-        LinuxLingo.main(new String[]{"exam", "-random"});
-        // Should not crash even if no questions loaded
-        assertTrue(true);
-    }
-
-    @Test
-    void oneShot_examTopicAndCountDoesNotCrash() {
-        LinuxLingo.main(new String[]{"exam", "-t", "navigation", "-n", "5"});
-        // Should not crash even if no questions loaded
-        assertTrue(true);
-    }
-
-    @Test
-    void oneShot_examTopicFlagDoesNotCrash() {
-        LinuxLingo.main(new String[]{"exam", "-t", "navigation"});
-        assertTrue(true);
-    }
-
-    @Test
-    void oneShot_examInvalidCountDoesNotCrash() {
-        LinuxLingo.main(new String[]{"exam", "-n", "notanumber"});
         String out = outBytes.toString();
-        assertTrue(out.contains("Invalid exam command") && out.contains("Usage"),
-                "Invalid -n value should show usage error, got: " + out);
+        assertTrue(out.contains("Available topics:"),
+                "-topics should list available topics, got: " + out);
     }
 
     @Test
-    void oneShot_examRandomWithTopicDoesNotCrash() {
-        LinuxLingo.main(new String[]{"exam", "-random", "-t", "navigation"});
-        assertTrue(true);
-    }
-
-    @Test
-    void oneShot_examUnknownArgsFallsBackToInteractive() {
-        LinuxLingo.main(new String[]{"exam", "-unknown"});
+    void oneShot_examRandomFlag_printsSingleQuestionPrompt() {
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("quit\nexit\n".getBytes()));
+        try {
+            LinuxLingo.main(new String[]{"exam", "-random"});
+        } finally {
+            System.setIn(originalIn);
+        }
         String out = outBytes.toString();
-        assertTrue(out.contains("Invalid exam command") && out.contains("Usage"),
-                "Unknown exam flag should show usage error, got: " + out);
+        assertTrue(out.contains("[Q1/1]"),
+                "Random one-shot exam should present a single question, got: " + out);
     }
 
     @Test
-    void oneShot_examDuplicateTopicFlagPrintsUsageError() {
-        LinuxLingo.main(new String[]{"exam", "-t", "navigation", "-t", "file-management"});
+    void oneShot_examInvalidTopic_listsAvailableTopics() {
+        LinuxLingo.main(new String[]{"exam", "-t", "definitely-not-a-real-topic", "-n", "5"});
         String out = outBytes.toString();
-        assertTrue(out.contains("Duplicate flag") && out.contains("Usage"),
-                "Duplicate -t should be rejected, got: " + out);
+        assertTrue(out.contains("Invalid topic selection."),
+                "Invalid topic should be rejected, got: " + out);
+        assertTrue(out.contains("Available topics:"),
+                "Invalid topic should be followed by the topic list, got: " + out);
     }
 
     @Test
-    void oneShot_examMissingTopicValuePrintsUsageError() {
-        LinuxLingo.main(new String[]{"exam", "-t"});
+    void oneShot_examRandomWithTopic_printsQuestionPrompt() {
+        java.io.InputStream originalIn = System.in;
+        System.setIn(new java.io.ByteArrayInputStream("quit\nexit\n".getBytes()));
+        try {
+            LinuxLingo.main(new String[]{"exam", "-random", "-t", "navigation"});
+        } finally {
+            System.setIn(originalIn);
+        }
         String out = outBytes.toString();
-        assertTrue(out.contains("Missing value") && out.contains("Usage"),
-                "Missing -t value should be rejected, got: " + out);
-    }
-
-    @Test
-    void oneShot_examCountWithoutTopicPrintsUsageError() {
-        LinuxLingo.main(new String[]{"exam", "-n", "5"});
-        String out = outBytes.toString();
-        assertTrue(out.contains("requires -t") && out.contains("Usage"),
-                "-n without -t should be rejected, got: " + out);
-    }
-
-    @Test
-    void oneShot_examCountAndRandomWithoutTopicPrintsUsageError() {
-        LinuxLingo.main(new String[]{"exam", "-n", "3", "-random"});
-        String out = outBytes.toString();
-        assertTrue(out.contains("requires -t") && out.contains("Usage"),
-                "-n with -random but without -t should be rejected, got: " + out);
+        assertTrue(out.contains("[Q1/"),
+                "Topic exam with -random should start an exam question, got: " + out);
     }
 
     // ─── shell one-shot mode ──────────────────────────────────────
@@ -196,8 +163,9 @@ public class LinuxLingoTest {
         } finally {
             System.setIn(originalIn);
         }
-        // Should not crash
-        assertTrue(true);
+        String out = outBytes.toString();
+        assertTrue(out.contains("Welcome to LinuxLingo Shell! Type 'exit' to quit."),
+            "Shell one-shot mode should show the shell welcome text, got: " + out);
     }
 
     // ─── No-args mode (interactive) — just ensure it doesn't hang ─

--- a/src/test/java/linuxlingo/ManualExamCliIntegrationTest.java
+++ b/src/test/java/linuxlingo/ManualExamCliIntegrationTest.java
@@ -1,0 +1,190 @@
+package linuxlingo;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import linuxlingo.cli.MainParser;
+import linuxlingo.cli.Ui;
+import linuxlingo.exam.ExamSession;
+import linuxlingo.exam.QuestionBank;
+import linuxlingo.shell.ShellSession;
+import linuxlingo.shell.vfs.VirtualFileSystem;
+
+/**
+ * End-to-end exam and top-level CLI scenarios derived from consolidated manual cases.
+ */
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+public class ManualExamCliIntegrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ByteArrayOutputStream outStream;
+
+    private MainParser createParser(String input, QuestionBank bank) {
+        outStream = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outStream);
+        ByteArrayInputStream in = new ByteArrayInputStream(input.getBytes());
+        Ui ui = new Ui(in, out);
+        VirtualFileSystem vfs = new VirtualFileSystem();
+        ShellSession shellSession = new ShellSession(vfs, ui);
+        ExamSession examSession = new ExamSession(bank, ui, VirtualFileSystem::new);
+        return new MainParser(ui, shellSession, examSession);
+    }
+
+    private ExamSession createExamSession(String input, QuestionBank bank) {
+        outStream = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outStream);
+        ByteArrayInputStream in = new ByteArrayInputStream(input.getBytes());
+        Ui ui = new Ui(in, out);
+        return new ExamSession(bank, ui, VirtualFileSystem::new);
+    }
+
+    private QuestionBank createBank() throws Exception {
+        Path questionsDir = tempDir.resolve("questions");
+        Files.createDirectories(questionsDir);
+
+        Files.writeString(questionsDir.resolve("navigation.txt"),
+                """
+                MCQ | EASY | Which command prints the current working directory? | B | A:cd B:pwd C:ls D:dir | pwd stands for print working directory.
+                FITB | EASY | To list files, type ___ | ls | | ls lists directory contents.
+                """);
+
+        Files.writeString(questionsDir.resolve("file-management.txt"),
+                """
+                MCQ | EASY | Which command removes a file? | C | A:mkdir B:pwd C:rm D:touch | rm removes files.
+                """);
+
+        Files.writeString(questionsDir.resolve("practical.txt"),
+                """
+                PRAC | EASY | Create a directory named testdir at root | /testdir:DIR | | Use mkdir to create directories.
+                """);
+
+        QuestionBank bank = new QuestionBank();
+        bank.load(questionsDir);
+        return bank;
+    }
+
+    @Test
+    void purav_invalidMcqInputAndInvalidTopic_repromptEndToEnd() throws Exception {
+        // PU-1, PU-3
+        QuestionBank bank = createBank();
+        MainParser parser = createParser(
+                "exam\n8\n1\n\npwd\nB\nls\nexit\n",
+                bank);
+
+        parser.run();
+
+        String output = outStream.toString();
+        assertTrue(output.contains("Invalid topic selection"));
+        assertTrue(output.contains("Invalid input"));
+        assertTrue(output.contains("Explanation:"));
+    }
+
+    @Test
+    void puravFitbAndPracFeedback_includeExplanationEndToEnd() throws Exception {
+        // PU-2
+        QuestionBank bank = createBank();
+
+        ExamSession fitbSession = createExamSession("B\nls\n", bank);
+        fitbSession.startWithArgs("navigation", 2, false);
+        String fitbOutput = outStream.toString();
+        assertTrue(fitbOutput.contains("Explanation:"));
+        assertTrue(fitbOutput.contains("Correct") || fitbOutput.contains("Incorrect"));
+
+        ExamSession pracSession = createExamSession("mkdir /testdir\nexit\n", bank);
+        pracSession.startWithArgs("practical", 1, false);
+        String pracOutput = outStream.toString();
+        assertTrue(pracOutput.contains("Entering Shell Simulator"));
+        assertTrue(pracOutput.contains("Explanation:"));
+    }
+
+    @Test
+    void puravPracQuitAndRandomQuit_areHandledGracefullyEndToEnd() throws Exception {
+        // PU-4, PU-5
+        QuestionBank bank = createBank();
+
+        ExamSession pracQuitSession = createExamSession("quit\nexit\n", bank);
+        pracQuitSession.startWithArgs("practical", 1, false);
+        String pracOutput = outStream.toString();
+        assertTrue(pracOutput.contains("Explanation:") || pracOutput.contains("Skipped")
+                || pracOutput.contains("Incorrect") || pracOutput.contains("Correct"));
+
+        MainParser parser = createParser("exam -random\nquit\nexit\n", bank);
+        parser.run();
+        String randomOutput = outStream.toString();
+        assertTrue(randomOutput.contains("[Q1/1]"));
+        assertTrue(randomOutput.contains("Skipped.")
+                || randomOutput.contains("Explanation:")
+                || randomOutput.contains("Correct")
+                || randomOutput.contains("Incorrect"));
+    }
+
+    @Test
+    void puravExamFlagMisuse_surfacesAsFormatProblemsEndToEnd() throws Exception {
+        // PU-6, PU-7
+        QuestionBank bank = createBank();
+
+        MainParser duplicateTopicParser = createParser(
+                "exam -t navigation -t file-management\nexit\n", bank);
+        duplicateTopicParser.run();
+        String duplicateOutput = outStream.toString();
+        assertTrue(duplicateOutput.contains("usage")
+                || duplicateOutput.contains("Invalid")
+                || duplicateOutput.contains("only one"));
+
+        MainParser missingTopicParser = createParser("exam -t\nexit\n", bank);
+        missingTopicParser.run();
+        String missingOutput = outStream.toString();
+        assertTrue(missingOutput.contains("usage")
+                || missingOutput.contains("Invalid")
+                || missingOutput.contains("missing"));
+
+        MainParser wrongFlagParser = createParser("exam -topic navigation\nexit\n", bank);
+        wrongFlagParser.run();
+        String wrongFlagOutput = outStream.toString();
+        assertTrue(wrongFlagOutput.contains("usage") || wrongFlagOutput.contains("Invalid"));
+    }
+
+    @Test
+    void michaelExecTopLevelFlows_workEndToEnd() throws Exception {
+        // MI-9.1 .. MI-9.7 and related main-parser exec cases.
+        QuestionBank bank = createBank();
+
+        MainParser simpleExec = createParser("exec \"echo hello\"\nexit\n", bank);
+        simpleExec.run();
+        assertTrue(outStream.toString().contains("hello"));
+
+        MainParser emptyExec = createParser("exec \"\"\nexit\n", bank);
+        emptyExec.run();
+        assertTrue(!outStream.toString().contains("Unknown command"));
+
+        MainParser pipelineExec = createParser("exec \"echo hello world | wc -w\"\nexit\n", bank);
+        pipelineExec.run();
+        assertTrue(outStream.toString().contains("2"));
+
+        MainParser missingEnvCommand = createParser("exec -e myenv\nexit\n", bank);
+        missingEnvCommand.run();
+        assertTrue(outStream.toString().contains("missing command")
+                || outStream.toString().contains("exec:")
+                || outStream.toString().contains("usage")
+                || outStream.toString().contains("Invalid"));
+
+        MainParser unknownTopLevel = createParser("foobar\nexit\n", bank);
+        unknownTopLevel.run();
+        assertTrue(outStream.toString().contains("Unknown command"));
+
+        MainParser bareExec = createParser("exec\nexit\n", bank);
+        bareExec.run();
+        assertTrue(outStream.toString().contains("missing command"));
+    }
+}

--- a/src/test/java/linuxlingo/cli/MainParserTest.java
+++ b/src/test/java/linuxlingo/cli/MainParserTest.java
@@ -212,6 +212,35 @@ public class MainParserTest {
     }
 
     @Test
+    public void run_examDuplicateTopicFlags_reportsUsageInsteadOfPickingSilently() {
+        MainParser parser = createParser("exam -t navigation -t file-management\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("usage")
+                || output.contains("Invalid")
+                || output.contains("only one"));
+    }
+
+    @Test
+    public void run_examMissingTopicAfterDashT_reportsUsageError() {
+        MainParser parser = createParser("exam -t\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("usage")
+                || output.contains("Invalid")
+                || output.contains("missing"));
+    }
+
+    @Test
+    public void run_examLongUnknownTopicFlag_reportsFormatError() {
+        MainParser parser = createParser("exam -topic navigation\nexit\n");
+        parser.run();
+        String output = outStream.toString();
+        assertTrue(output.contains("usage")
+                || output.contains("Invalid"));
+    }
+
+    @Test
     public void run_examUnknownFlag_fallsBackGracefully() {
         MainParser parser = createParser("exam -unknown\nexit\n");
         parser.run();

--- a/src/test/java/linuxlingo/exam/ExamSessionTest.java
+++ b/src/test/java/linuxlingo/exam/ExamSessionTest.java
@@ -116,6 +116,18 @@ public class ExamSessionTest {
     }
 
     @Test
+    public void startInteractive_invalidTopicName_printsErrorAndReprompts() throws Exception {
+        QuestionBank bank = createBankWithQuestions();
+        ExamSession session = createSession("navigashun\n1\n\nB\nls\n", bank);
+        session.startInteractive();
+
+        String output = outStream.toString();
+        assertTrue(output.contains("Invalid topic selection"));
+        assertTrue(output.contains("navigation"));
+        assertTrue(output.contains("[Q"), "Should continue after a corrected topic selection");
+    }
+
+    @Test
     public void startWithArgs_invalidTopic_printsError() throws Exception {
         QuestionBank bank = createBankWithQuestions();
         ExamSession session = createSession("", bank);


### PR DESCRIPTION
## Summary
- reject unexpected arguments passed to the top-level `shell` command in both one-shot and interactive flows
- tighten `exec -e` validation and improve related CLI regression coverage
- add exam CLI integration coverage for the updated top-level parsing paths

## Testing
- ./gradlew clean test --no-daemon

Closes #214