### PR TITLE
Fix PE bugs #13 (save/load crash on pipe in filename) and #26 (save overwrite protection)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -697,15 +697,21 @@ These commands let you save, load, and manage snapshots of the virtual file syst
 
 Saves the current VFS state and working directory as a named snapshot.
 
-Format: `save NAME`
+Format: `save [-f] NAME`
 
 - The name can only contain letters, digits, hyphens, and underscores.
 - Snapshots are stored in the `data/environments/` folder.
+- If an environment with the given name already exists, `save` fails to protect
+  against accidental overwrite. Pass `-f` (or `--force`) to overwrite.
 
 Example:
 
 ```text
 user@linuxlingo:/home/user$ save my-workspace
+Environment saved: my-workspace
+user@linuxlingo:/home/user$ save my-workspace
+save: environment 'my-workspace' already exists. Use 'save -f my-workspace' to overwrite.
+user@linuxlingo:/home/user$ save -f my-workspace
 Environment saved: my-workspace
 ```
 

--- a/src/main/java/linuxlingo/shell/command/SaveCommand.java
+++ b/src/main/java/linuxlingo/shell/command/SaveCommand.java
@@ -7,19 +7,37 @@ import linuxlingo.storage.VfsSerializer;
 
 /**
  * Saves the current VFS state to a named environment file.
- * Syntax: save &lt;name&gt;
+ * Syntax: save [-f] &lt;name&gt;
+ *
+ * <p>By default, fails if an environment with the given name already exists,
+ * to prevent silent data loss. Use {@code -f} (force) to overwrite.</p>
  *
  * <p><b>Owner: B</b></p>
  */
 public class SaveCommand implements Command {
     @Override
     public CommandResult execute(ShellSession session, String[] args, String stdin) {
-        if (args.length != 1) {
+        boolean force = false;
+        String name = null;
+        for (String arg : args) {
+            if ("-f".equals(arg) || "--force".equals(arg)) {
+                force = true;
+            } else if (name == null) {
+                name = arg;
+            } else {
+                return CommandResult.error("save: usage: " + getUsage());
+            }
+        }
+        if (name == null) {
             return CommandResult.error("save: usage: " + getUsage());
         }
-        String name = args[0];
         if (!name.matches("[a-zA-Z0-9_-]+")) {
             return CommandResult.error("save: invalid environment name: " + name);
+        }
+        if (!force && VfsSerializer.environmentExists(name)) {
+            return CommandResult.error(
+                    "save: environment '" + name + "' already exists. "
+                            + "Use 'save -f " + name + "' to overwrite.");
         }
         try {
             VfsSerializer.saveToFile(session.getVfs(), session.getWorkingDir(), name);
@@ -31,7 +49,7 @@ public class SaveCommand implements Command {
 
     @Override
     public String getUsage() {
-        return "save <name>";
+        return "save [-f] <name>";
     }
 
     @Override

--- a/src/main/java/linuxlingo/storage/VfsSerializer.java
+++ b/src/main/java/linuxlingo/storage/VfsSerializer.java
@@ -155,7 +155,7 @@ public class VfsSerializer {
                 continue;
             }
             String type = parts[0].trim();
-            String path = parts[1].trim();
+            String path = unescapeContent(parts[1].trim());
             String permString = parts[2].trim();
             Permission permission = new Permission(permString);
 
@@ -260,6 +260,17 @@ public class VfsSerializer {
         return Storage.delete(path);
     }
 
+    /**
+     * Check whether an environment with the given name already exists on disk.
+     *
+     * @param name environment name
+     * @return true if {@code data/environments/<name>.env} exists
+     */
+    public static boolean environmentExists(String name) {
+        Path path = Storage.getDataSubDir("environments").resolve(name + ".env");
+        return Storage.exists(path);
+    }
+
     // ─── Escaping helpers ────────────────────────────────────────
 
     /**
@@ -327,7 +338,7 @@ public class VfsSerializer {
     private static void appendNode(FileNode node, StringBuilder sb) {
         if (node.isDirectory()) {
             sb.append("DIR  | ")
-                    .append(node.getAbsolutePath())
+                    .append(escapeContent(node.getAbsolutePath()))
                     .append(" | ")
                     .append(node.getPermission())
                     .append("\n");
@@ -338,7 +349,7 @@ public class VfsSerializer {
         }
         RegularFile file = (RegularFile) node;
         sb.append("FILE | ")
-                .append(file.getAbsolutePath())
+                .append(escapeContent(file.getAbsolutePath()))
                 .append(" | ")
                 .append(file.getPermission())
                 .append(" | ")

--- a/src/test/java/linuxlingo/storage/VfsSerializerTest.java
+++ b/src/test/java/linuxlingo/storage/VfsSerializerTest.java
@@ -99,6 +99,30 @@ public class VfsSerializerTest {
     }
 
     @Test
+    public void serializeAndDeserialize_filenameWithPipe_roundTrips() {
+        VirtualFileSystem vfs = new VirtualFileSystem();
+        vfs.createFile("/tmp/a | b", "/");
+        vfs.writeFile("/tmp/a | b", "/", "hello", false);
+
+        String serialized = VfsSerializer.serialize(vfs, "/");
+        VfsSerializer.DeserializedVfs result = VfsSerializer.deserialize(serialized);
+
+        assertEquals("hello", result.getVfs().readFile("/tmp/a | b", "/"));
+    }
+
+    @Test
+    public void serializeAndDeserialize_directoryNameWithPipe_roundTrips() {
+        VirtualFileSystem vfs = new VirtualFileSystem();
+        vfs.createDirectory("/tmp/odd | dir", "/", false);
+        vfs.createFile("/tmp/odd | dir/inside.txt", "/");
+
+        String serialized = VfsSerializer.serialize(vfs, "/");
+        VfsSerializer.DeserializedVfs result = VfsSerializer.deserialize(serialized);
+
+        assertNotNull(result.getVfs().resolve("/tmp/odd | dir/inside.txt", "/"));
+    }
+
+    @Test
     public void listEnvironments_emptyDir_returnsEmptyList() {
         // Just checking that it doesn't crash
         var names = VfsSerializer.listEnvironments();


### PR DESCRIPTION
Fixes PE issue [#13](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/13) and [#26](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/26).

## #13 — save/load crashes when a filename contains `|`

The `.env` serializer used ` | ` as a field delimiter but did not escape pipes inside the path field. A file named `a | b` produced an ambiguous line that, on deserialize, was misparsed into `["FILE", "/home/user/a", "b", ...]` and threw `IllegalArgumentException` from `new Permission("b")`, crashing the whole app.

**Fix:** Apply the existing `escapeContent` / `unescapeContent` helpers to paths on both serialize and deserialize. Round-trip tests added for filenames and directory names containing pipe.

Verified end-to-end with the released jar:

```
> exec "cd /home/user ; touch 'a | b' ; ls /home/user"
a | b
> exec "save badpipe2"
Environment saved: badpipe2
> exec "load badpipe2"
Environment loaded: badpipe2
> exec "ls /home/user"
a | b
```

## #26 — `save` silently overwrites existing environments

Previously `save myenv` on an existing `myenv` silently replaced the old snapshot, potentially destroying hours of setup from a typo.

**Fix:** By default, `save` now refuses to overwrite and prints:
`save: environment 'myenv' already exists. Use 'save -f myenv' to overwrite.`
A new `-f` / `--force` flag opts into overwrite. UG updated.

## Checks

- `./gradlew test` — all pass (new tests for pipe in file/dir names, existing tests unchanged)
- `./gradlew checkstyleMain checkstyleTest` — pass
- Manual end-to-end repro verified on shadow jar

Leaving this open for team review — not self-merging.