### PR TITLE
Fix #22: honor -- end-of-options marker in combined-flag expansion

### DIFF
--- a/src/main/java/linuxlingo/shell/ShellSession.java
+++ b/src/main/java/linuxlingo/shell/ShellSession.java
@@ -791,12 +791,27 @@ public class ShellSession {
      * Skips arguments that are a single flag, numeric flags like {@code -5},
      * or long-form flags.
      *
+     * <p>If a standalone {@code --} is encountered, flag expansion stops
+     * immediately and every subsequent argument is passed through literally,
+     * matching standard POSIX end-of-options behaviour. This lets users pass
+     * dash-prefixed filenames (e.g. {@code touch -- -abc}).</p>
+     *
      * @param args the original arguments
      * @return expanded arguments with combined flags split
      */
     public String[] expandCombinedFlags(String[] args) {
         List<String> expanded = new ArrayList<>();
+        boolean endOfOptions = false;
         for (String arg : args) {
+            if (endOfOptions) {
+                expanded.add(arg);
+                continue;
+            }
+            if ("--".equals(arg)) {
+                // Consume the marker; subsequent args pass through literally.
+                endOfOptions = true;
+                continue;
+            }
             // Expand if it starts with '-', has 3-6 chars (2-5 combined flags),
             // doesn't start with '--', all chars after '-' are letters, and
             // the flag text isn't a known multi-char option word (#145).

--- a/src/test/java/linuxlingo/shell/ShellSessionTest.java
+++ b/src/test/java/linuxlingo/shell/ShellSessionTest.java
@@ -333,6 +333,26 @@ class ShellSessionTest {
     }
 
     @Test
+    void expandCombinedFlags_standaloneDoubleDash_stopsExpansionAndIsStripped() {
+        ShellSession session = createSession("");
+        String[] result = session.expandCombinedFlags(
+                new String[]{"-l", "--", "-abc", "-xy"});
+        assertEquals(3, result.length);
+        assertEquals("-l", result[0]);
+        assertEquals("-abc", result[1]);
+        assertEquals("-xy", result[2]);
+    }
+
+    @Test
+    void expandCombinedFlags_doubleDashAtStart_passesDashFileLiterally() {
+        ShellSession session = createSession("");
+        String[] result = session.expandCombinedFlags(
+                new String[]{"--", "-abc"});
+        assertEquals(1, result.length);
+        assertEquals("-abc", result[0]);
+    }
+
+    @Test
     void expandCombinedFlags_numericFlag_unchanged() {
         ShellSession session = createSession("");
         String[] result = session.expandCombinedFlags(new String[]{"-5"});


### PR DESCRIPTION
Fixes PE issue [#22](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/22).

## Bug
`touch -- -abc` was expected to create a single file named `-abc`, but instead created three files: `-a`, `-b`, `-c`. The shell's `expandCombinedFlags()` was treating `-abc` as combined short flags and splitting it, ignoring the `--` end-of-options marker entirely.

## Fix
`ShellSession.expandCombinedFlags()` now:
1. Stops combined-flag expansion when it encounters a standalone `--`.
2. Drops the `--` marker (commands shouldn't need to handle it themselves).
3. Passes every subsequent argument through unchanged.

This matches standard POSIX end-of-options behaviour and means dash-prefixed filenames can be created/manipulated across any command that takes paths, not just `touch`.

## Verified end-to-end
```
> exec "cd /home/user ; touch -- -abc ; ls /home/user"
-abc
```

Two new tests cover the `--` stop-and-strip behaviour plus the leading-`--` case. Checkstyle + full test suite pass.