### PR TITLE
Fix #30: auto-list completions so TAB never prompts mid-input

### DIFF
--- a/src/main/java/linuxlingo/shell/ShellLineReader.java
+++ b/src/main/java/linuxlingo/shell/ShellLineReader.java
@@ -99,6 +99,15 @@ public class ShellLineReader {
         // through literally to ShellParser (which handles its own escaping).
         reader.setOpt(LineReader.Option.DISABLE_EVENT_EXPANSION);
 
+        // Auto-list all completion candidates on an ambiguous completion
+        // instead of asking "do you wish to see all N possibilities?". The
+        // prompt was visually concatenating with the user's next keystroke
+        // and produced confusing output when a user hit TAB with empty
+        // input and then typed something (PE issue #30). The whole command
+        // set is ~35 items, so auto-listing is fine.
+        reader.setOpt(LineReader.Option.AUTO_LIST);
+        reader.setVariable(LineReader.LIST_MAX, 1000);
+
         return new ShellLineReader(reader, terminal, history);
     }
 


### PR DESCRIPTION
Fixes PE issue [#30](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/30).

## Bug
When the user pressed TAB on an empty prompt, JLine showed `do you wish to see all 35 possibilities?` and waited for a keystroke. If the user then typed something like `1.`, the question text visually concatenated with their keystroke and the subsequent command-not-found error:

```
user@linuxlingo:/home/user$ [TAB] + "1."

JLine terminal: do you wish to see all 35 possibilities (0 lines)?.: command not found
Did you mean 'cd'?
```

## Fix
Enable JLine's `AUTO_LIST` option and raise `LIST_MAX` to 1000 so the reader just lists the 35 candidates directly instead of prompting. No confirmation prompt ever appears, so there's nothing to visually concatenate with the user's input.

Checkstyle + full test suite pass.