### PR TITLE
Fix #12: label shell-mode help clearly so it is not confused with main menu

### DIFF
--- a/src/main/java/linuxlingo/shell/command/HelpCommand.java
+++ b/src/main/java/linuxlingo/shell/command/HelpCommand.java
@@ -15,7 +15,11 @@ public class HelpCommand implements Command {
     @Override
     public CommandResult execute(ShellSession session, String[] args, String stdin) {
         if (args.length == 0) {
-            StringBuilder out = new StringBuilder("Available commands:");
+            StringBuilder out = new StringBuilder(
+                    "Shell mode — Linux-style commands available in this session.\n"
+                    + "Type 'help <command>' for details on a specific command, "
+                    + "or 'exit' to leave shell mode.\n\n"
+                    + "Available commands:");
             for (Map.Entry<String, String> entry : session.getRegistry().getHelpText().entrySet()) {
                 out.append(String.format("\n  %-20s %s", entry.getKey(), entry.getValue()));
             }


### PR DESCRIPTION
Fixes PE issue [#12](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/12).

## Bug
Shell-mode `help` already returned the shell commands (ls, cd, pwd, ...), but the header was just `Available commands:` — identical in format to the main-menu help. Testers typing `help` inside shell mode thought they'd landed on the main-menu help.

## Fix
Prepend a short, unambiguous header:

> Shell mode — Linux-style commands available in this session.
> Type 'help <command>' for details on a specific command, or 'exit' to leave shell mode.

No behavioural changes; the command list is unchanged. Existing tests still pass (they check for `Available commands:` which is retained).

Checkstyle + full test suite pass.