### PR TITLE
Fix #29: force UTF-8 on stdout/stderr for Windows non-ASCII output

### DIFF
--- a/src/main/java/linuxlingo/LinuxLingo.java
+++ b/src/main/java/linuxlingo/LinuxLingo.java
@@ -1,5 +1,7 @@
 package linuxlingo;
 
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,6 +37,13 @@ public class LinuxLingo {
      * @param args command-line arguments; empty for interactive mode.
      */
     public static void main(String[] args) {
+        // Force UTF-8 on stdout/stderr so non-ASCII characters (e.g. Chinese,
+        // Japanese, Cyrillic) survive redirection and display on platforms
+        // whose default console encoding is not UTF-8 (notably Windows,
+        // where it defaults to cp1252). Fixes PE issue #29.
+        System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(System.err, true, StandardCharsets.UTF_8));
+
         // Suppress internal Java logger messages from leaking to stderr (#142)
         Logger rootLogger = Logger.getLogger("");
         rootLogger.setLevel(Level.SEVERE);


### PR DESCRIPTION
Fixes PE issue [#29](https://github.com/NUS-CS2113-AY2526-S2/pe-CS2113-T10-2/issues/29).

## Bug
On Windows, stdout defaults to cp1252. Non-ASCII text (Chinese, Japanese, Korean, Russian, Arabic, Devanagari, …) written to stdout became `?` as soon as Java encoded it for the terminal. The VFS itself stored the text correctly, but `cat` output through `System.out` lost it.

## Fix
Wrap `System.out` and `System.err` in `PrintStream`s that use `StandardCharsets.UTF_8` at the start of `main()`. Linux/macOS default to UTF-8 so this is a no-op there; Windows users on modern Terminal/PowerShell (UTF-8 capable) now get correct output.

Legacy cmd.exe may still need `chcp 65001` — that is a terminal-level setting outside what the app can fix.

Checkstyle + full test suite pass.